### PR TITLE
(build) Externalize apollo components

### DIFF
--- a/build/rollup.config.base.js
+++ b/build/rollup.config.base.js
@@ -23,4 +23,5 @@ export default {
       VERSION: JSON.stringify(config.version),
     }),
   ],
+  external: ['apollo-client', 'apollo-link', 'graphql-tag'],
 }

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -116,6 +116,23 @@ new Vue({
 
 You are now ready to use Apollo in your components!
 
+
+### 4. (OPTIONAL) Install Apollo Components
+
+These components were externalized to allow opting in for them to reduce bundle size.  To Install
+
+```js
+import Vue from 'vue';
+import useApolloComponents from 'node_modules/vue-apollo/components/useApolloComponents'
+
+Vue.install(useApolloComponents)
+```
+
+This will provide 
+ - ApolloQuery
+ - ApolloMutation
+ - ApolloSubscribeToMore
+
 ## IDE integration
 
 ### Visual Studio Code

--- a/src/components/useApolloComponents.js
+++ b/src/components/useApolloComponents.js
@@ -1,0 +1,17 @@
+import CApolloQuery from './components/ApolloQuery'
+import CApolloSubscribeToMore from './components/ApolloSubscribeToMore'
+import CApolloMutation from './components/ApolloMutation'
+
+// Components
+export const ApolloQuery = CApolloQuery
+export const ApolloSubscribeToMore = CApolloSubscribeToMore
+export const ApolloMutation = CApolloMutation
+
+export function install (vue) {
+  vue.component('apollo-query', CApolloQuery)
+  vue.component('ApolloQuery', CApolloQuery)
+  vue.component('apollo-subscribe-to-more', CApolloSubscribeToMore)
+  vue.component('ApolloSubscribeToMore', CApolloSubscribeToMore)
+  vue.component('apollo-mutation', CApolloMutation)
+  vue.component('ApolloMutation', CApolloMutation)
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,6 @@
 import { DollarApollo } from './dollar-apollo'
 import { ApolloProvider as plugin } from './apollo-provider'
 
-import CApolloQuery from './components/ApolloQuery'
-import CApolloSubscribeToMore from './components/ApolloSubscribeToMore'
-import CApolloMutation from './components/ApolloMutation'
-
 import { installMixin } from './mixin'
 import { Globals, omit } from '../lib/utils'
 
@@ -48,15 +44,6 @@ export function install (Vue, options) {
   })
 
   installMixin(Vue, vueVersion)
-
-  if (vueVersion === '2') {
-    Vue.component('apollo-query', CApolloQuery)
-    Vue.component('ApolloQuery', CApolloQuery)
-    Vue.component('apollo-subscribe-to-more', CApolloSubscribeToMore)
-    Vue.component('ApolloSubscribeToMore', CApolloSubscribeToMore)
-    Vue.component('apollo-mutation', CApolloMutation)
-    Vue.component('ApolloMutation', CApolloMutation)
-  }
 }
 
 plugin.install = install
@@ -66,11 +53,6 @@ plugin.version = VERSION
 
 // Apollo provider
 export const ApolloProvider = plugin
-
-// Components
-export const ApolloQuery = CApolloQuery
-export const ApolloSubscribeToMore = CApolloSubscribeToMore
-export const ApolloMutation = CApolloMutation
 
 // Auto-install
 let GlobalVue = null


### PR DESCRIPTION
This PR reduces the size of the library by between 60-65% across esm/min/umd builds

This PR builds on top of #722 and extracts Apollo components into an includable plugin.  I don't think that we require people who are not including these components to include in the bundle.  

|Library|Before|After WithExternals|After Removing Apollo Components|
|---|---|---|---|
|esm|133k|57k|48k|
|min|52k|26k|21k|
|umd|142k|61k|51k|

```bash
# Current Build
drwxrwxr-x  2 talos talos   4096 Jul  5 11:50 .
drwxrwxr-x 16 talos talos   4096 Aug  7 10:26 ..
-rw-rw-r--  1 talos talos 133190 Aug  7 10:27 vue-apollo.esm.js
-rw-rw-r--  1 talos talos  52935 Aug  7 10:26 vue-apollo.min.js
-rw-rw-r--  1 talos talos 142186 Aug  7 10:27 vue-apollo.umd.js

# With externals
drwxrwxr-x  2 talos talos  4096 Jul  5 11:50 .
drwxrwxr-x 16 talos talos  4096 Aug  7 10:26 ..
-rw-rw-r--  1 talos talos 57047 Aug  7 10:28 vue-apollo.esm.js
-rw-rw-r--  1 talos talos 26922 Aug  7 10:28 vue-apollo.min.js
-rw-rw-r--  1 talos talos 61127 Aug  7 10:28 vue-apollo.umd.js

# With removing apollo
drwxrwxr-x  2 talos talos  4096 Jul  5 11:50 .
drwxrwxr-x 16 talos talos  4096 Aug  7 10:26 ..
-rw-rw-r--  1 talos talos 48084 Aug  7 11:03 vue-apollo.esm.js
-rw-rw-r--  1 talos talos 21970 Aug  7 11:03 vue-apollo.min.js
-rw-rw-r--  1 talos talos 51291 Aug  7 11:03 vue-apollo.umd.js
```