### PR TITLE
Apollo Client 3 updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -23,7 +23,7 @@ A clear and concise description of what you expected to happen.
 **Versions**
 vue:
 vue-apollo:
-apollo-client:
+@apollo/client:
 
 **Additional context**
 Add any other context about the problem here.

--- a/build/rollup.config.base.js
+++ b/build/rollup.config.base.js
@@ -23,5 +23,5 @@ export default {
       VERSION: JSON.stringify(config.version),
     }),
   ],
-  external: ['@apollo/client', 'apollo-link', 'graphql-tag'],
+  external: ['@apollo/client', 'graphql-tag'],
 }

--- a/build/rollup.config.base.js
+++ b/build/rollup.config.base.js
@@ -23,5 +23,5 @@ export default {
       VERSION: JSON.stringify(config.version),
     }),
   ],
-  external: ['@apollo/client', 'graphql-tag'],
+  external: ['@apollo/client'],
 }

--- a/build/rollup.config.base.js
+++ b/build/rollup.config.base.js
@@ -23,5 +23,5 @@ export default {
       VERSION: JSON.stringify(config.version),
     }),
   ],
-  external: ['apollo-client', 'apollo-link', 'graphql-tag'],
+  external: ['@apollo/client', 'apollo-link', 'graphql-tag'],
 }

--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -48,7 +48,7 @@ In the `apollo` object, add an attribute for each property you want to feed with
 </template>
 
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   apollo: {

--- a/docs/guide/apollo/pagination.md
+++ b/docs/guide/apollo/pagination.md
@@ -31,7 +31,7 @@ Example:
 </template>
 
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 const pageSize = 10
 

--- a/docs/guide/apollo/queries.md
+++ b/docs/guide/apollo/queries.md
@@ -15,7 +15,7 @@ In the `apollo` object, add an attribute for each property you want to feed with
 Use `gql` to write your GraphQL queries:
 
 ```js
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 ```
 
 Put the [gql](https://github.com/apollographql/graphql-tag) query directly as the value:

--- a/docs/guide/apollo/subscriptions.md
+++ b/docs/guide/apollo/subscriptions.md
@@ -7,18 +7,19 @@
 To enable the websocket-based subscription, a bit of additional setup is required:
 
 ```
-npm install --save apollo-link-ws apollo-utilities
+npm install --save apollo-link-ws
 ```
 
 ```js
 import Vue from 'vue'
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-// New Imports
-import { split } from 'apollo-link'
+import {
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  split,
+  getMainDefinition
+} from '@apollo/client'
 import { WebSocketLink } from 'apollo-link-ws'
-import { getMainDefinition } from 'apollo-utilities'
 
 import VueApollo from 'vue-apollo'
 

--- a/docs/guide/components/query.md
+++ b/docs/guide/components/query.md
@@ -1,6 +1,6 @@
 # ApolloQuery
 
-You can use the `ApolloQuery` (or `apollo-query`) component to have watched Apollo queries directly in your template. 
+You can use the `ApolloQuery` (or `apollo-query`) component to have watched Apollo queries directly in your template.
 After reading this page, see the [API Reference](../../api/apollo-query.md) for all the possible options.
 
 ## Query gql tag
@@ -245,7 +245,7 @@ We want to extract all the fields in `messages` of the `Message` type into a fra
 First import the `gql` tag in the component:
 
 ```js
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 ```
 
 Then, inside the component definition, declare a new `fragments` object:
@@ -356,7 +356,7 @@ Here is the full example component:
 ```vue
 <!-- MessageList.vue -->
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   fragments: {
@@ -398,7 +398,7 @@ Now we can retrieve the `message` fragment in another component:
 ```vue
 <!-- MessageForm.vue -->
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 import MessageList from './MessageList.vue'
 
 export default {

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -18,69 +18,24 @@ Then you can skip to next section: [Basic Usage](./apollo/).
 
 ### 1. Apollo Client
 
-You can either use [Apollo Boost](#apollo-boost) or [Apollo Client directly](#apollo-client-full-configuration) (more configuration work).
-
-#### Apollo Boost
-
-Apollo Boost is a zero-config way to start using Apollo Client. It includes some sensible defaults, such as our recommended `InMemoryCache` and `HttpLink`, which come configured for you with our recommended settings and it's perfect for starting to develop fast.
-
-Install it alongside `vue-apollo` and `graphql`: 
-
 ```
-npm install --save vue-apollo graphql apollo-boost
+npm install --save vue-apollo graphql @apollo/client
 ```
 
 Or:
 
 ```
-yarn add vue-apollo graphql apollo-boost
+yarn add vue-apollo graphql @apollo/client
 ```
 
 In your app, create an `ApolloClient` instance:
 
 ```js
-import ApolloClient from 'apollo-boost'
+import { ApolloClient } from '@apollo/client';
 
 const apolloClient = new ApolloClient({
   // You should use an absolute URL here
   uri: 'https://api.graphcms.com/simple/v1/awesomeTalksClone'
-})
-```
-
-#### Apollo client full configuration
-
-If you want some more fine grained control install these packages instead of apollo-boost:
-
-```
-npm install --save vue-apollo graphql apollo-client apollo-link apollo-link-http apollo-cache-inmemory graphql-tag
-```
-
-Or:
-
-```
-yarn add vue-apollo graphql apollo-client apollo-link apollo-link-http apollo-cache-inmemory graphql-tag
-```
-
-In your app, create an `ApolloClient` instance:
-
-```js
-import { ApolloClient } from 'apollo-client'
-import { createHttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-
-// HTTP connection to the API
-const httpLink = createHttpLink({
-  // You should use an absolute URL here
-  uri: 'http://localhost:3020/graphql',
-})
-
-// Cache implementation
-const cache = new InMemoryCache()
-
-// Create the apollo client
-const apolloClient = new ApolloClient({
-  link: httpLink,
-  cache,
 })
 ```
 

--- a/docs/guide/local-state.md
+++ b/docs/guide/local-state.md
@@ -25,7 +25,7 @@ Now we're ready to add an `Item` type to our local GraphQL schema.
 ```js
 //main.js
 
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client'
 
 export const typeDefs = gql`
   type Item {
@@ -92,11 +92,10 @@ const userQuery = gql`
 
 To initialize an Apollo cache in your application, you will need to use an `InMemoryCache` constructor. First, let's import it to your main file:
 
-```js{4,6}
+```js{4,5}
 // main.js
 
-import ApolloClient from 'apollo-boost';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
 
 const cache = new InMemoryCache();
 ```
@@ -147,7 +146,7 @@ Querying local cache is very similar to [sending GraphQL queries to remote serve
 ```js
 // App.vue
 
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client'
 
 const todoItemsQuery = gql`
   {

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -121,13 +121,11 @@ If `ssr` is false, we try to restore the state of the Apollo cache with `cache.r
 
 Here is an example:
 
-```js{21-30}
+```js
 // apollo.js
 
 import Vue from 'vue'
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
 import VueApollo from 'vue-apollo'
 
 // Install the vue plugin

--- a/docs/zh-cn/guide/apollo/README.md
+++ b/docs/zh-cn/guide/apollo/README.md
@@ -48,7 +48,7 @@ export default {
 </template>
 
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   apollo: {

--- a/docs/zh-cn/guide/apollo/pagination.md
+++ b/docs/zh-cn/guide/apollo/pagination.md
@@ -30,7 +30,7 @@
 </template>
 
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 const pageSize = 10
 

--- a/docs/zh-cn/guide/apollo/queries.md
+++ b/docs/zh-cn/guide/apollo/queries.md
@@ -15,7 +15,7 @@ query myHelloQueryName {
 使用 `gql` 编写你的 GraphQL 查询：
 
 ```js
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 ```
 
 直接将 [gql](https://github.com/apollographql/graphql-tag) 查询作为值：

--- a/docs/zh-cn/guide/apollo/subscriptions.md
+++ b/docs/zh-cn/guide/apollo/subscriptions.md
@@ -7,18 +7,19 @@
 要启用基于 websocket 的订阅，需要做一些额外的设置：
 
 ```
-npm install --save apollo-link-ws apollo-utilities
+npm install --save apollo-link-ws
 ```
 
 ```js
 import Vue from 'vue'
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
-// 新的引入文件
-import { split } from 'apollo-link'
+import {
+  ApolloClient,
+  HttpLink,
+  InMemoryCache,
+  split,
+  getMainDefinition
+} from '@apollo/client'
 import { WebSocketLink } from 'apollo-link-ws'
-import { getMainDefinition } from 'apollo-utilities'
 
 import VueApollo from 'vue-apollo'
 

--- a/docs/zh-cn/guide/components/query.md
+++ b/docs/zh-cn/guide/components/query.md
@@ -246,7 +246,7 @@ query GetMessages {
 首先将 `gql` 标签导入组件：
 
 ```js
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 ```
 
 然后，在组件定义中，声明一个新的 `fragments` 对象：
@@ -357,7 +357,7 @@ fragment message on Message {
 ```vue
 <!-- MessageList.vue -->
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   fragments: {
@@ -399,7 +399,7 @@ export default {
 ```vue
 <!-- MessageForm.vue -->
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 import MessageList from './MessageList.vue'
 
 export default {

--- a/docs/zh-cn/guide/local-state.md
+++ b/docs/zh-cn/guide/local-state.md
@@ -25,7 +25,7 @@
 ```js
 //main.js
 
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client'
 
 export const typeDefs = gql`
   type Item {
@@ -92,11 +92,10 @@ const userQuery = gql`
 
 要在应用中初始化 Apollo 缓存，需要使用 `InMemoryCache` 构造函数。首先，将它导入你的主文件：
 
-```js{4,6}
+```js{4,5}
 // main.js
 
-import ApolloClient from 'apollo-boost';
-import { InMemoryCache } from 'apollo-cache-inmemory';
+import { ApolloClient, InMemoryCache } from '@apollo/client';
 
 const cache = new InMemoryCache();
 ```
@@ -147,7 +146,7 @@ cache.writeData({
 ```js
 // App.vue
 
-import gql from 'graphql-tag';
+import { gql } from '@apollo/client'
 
 const todoItemsQuery = gql`
   {

--- a/docs/zh-cn/guide/ssr.md
+++ b/docs/zh-cn/guide/ssr.md
@@ -121,13 +121,11 @@ export default {
 
 这里是一个示例：
 
-```js{21-30}
+```js
 // apollo.js
 
 import Vue from 'vue'
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache } from 'apollo-cache-inmemory'
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client'
 import VueApollo from 'vue-apollo'
 
 // 安装 vue 插件

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@babel/preset-env": "^7.1.0",
     "@types/graphql": "^14.0.1",
     "@vue/test-utils": "^1.0.0-beta.25",
-    "apollo-cache-inmemory": "^1.2.9",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "cross-env": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
   },
   "homepage": "https://github.com/Akryum/vue-apollo#readme",
   "peerDependencies": {
-    "@apollo/client": "^3.0.0-beta.7",
-    "graphql-tag": "^2.10.1"
+    "@apollo/client": "^3.0.0-beta.7"
   },
   "dependencies": {
     "chalk": "^2.4.2",
@@ -65,7 +64,6 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "graphql": "^14.0.2",
-    "graphql-tag": "^2.5.0",
     "jest": "^24.8.0",
     "nodemon": "^1.18.4",
     "rimraf": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "homepage": "https://github.com/Akryum/vue-apollo#readme",
   "peerDependencies": {
     "@apollo/client": "^3.0.0-beta.7",
-    "apollo-link": "^1.0.0",
     "graphql-tag": "^2.10.1"
   },
   "dependencies": {
@@ -56,8 +55,6 @@
     "@types/graphql": "^14.0.1",
     "@vue/test-utils": "^1.0.0-beta.25",
     "apollo-cache-inmemory": "^1.2.9",
-    "apollo-link": "^1.0.3",
-    "apollo-link-http": "^1.2.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.1",
     "cross-env": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   },
   "homepage": "https://github.com/Akryum/vue-apollo#readme",
   "peerDependencies": {
-    "apollo-client": "^2.0.0",
+    "@apollo/client": "^3.0.0-beta.7",
     "apollo-link": "^1.0.0",
     "graphql-tag": "^2.10.1"
   },
@@ -48,6 +48,7 @@
     "throttle-debounce": "^2.1.0"
   },
   "devDependencies": {
+    "@apollo/client": "^3.0.0-beta.7",
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
     "@babel/plugin-transform-for-of": "^7.4.4",
@@ -55,7 +56,6 @@
     "@types/graphql": "^14.0.1",
     "@vue/test-utils": "^1.0.0-beta.25",
     "apollo-cache-inmemory": "^1.2.9",
-    "apollo-client": "^2.4.1",
     "apollo-link": "^1.0.3",
     "apollo-link-http": "^1.2.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/components/ApolloMutation.js
+++ b/src/components/ApolloMutation.js
@@ -1,5 +1,5 @@
 import { addGqlError } from '../../lib/utils'
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 export default {
   props: {

--- a/src/components/ApolloMutation.js
+++ b/src/components/ApolloMutation.js
@@ -1,5 +1,5 @@
 import { addGqlError } from '../../lib/utils'
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   props: {

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 function isDataFilled (data) {
   return Object.keys(data).length > 0

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 function isDataFilled (data) {
   return Object.keys(data).length > 0

--- a/src/components/ApolloSubscribeToMore.js
+++ b/src/components/ApolloSubscribeToMore.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 let uid = 0
 

--- a/src/components/ApolloSubscribeToMore.js
+++ b/src/components/ApolloSubscribeToMore.js
@@ -1,4 +1,4 @@
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 let uid = 0
 

--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -128,7 +128,7 @@ export default class SmartQuery extends SmartApollo {
   }
 
   maySetLoading (force = false) {
-    const currentResult = this.observer.currentResult()
+    const currentResult = this.observer.getCurrentResult()
     if (force || currentResult.loading) {
       if (!this.loading) {
         this.applyLoadingModifier(1)
@@ -199,7 +199,7 @@ export default class SmartQuery extends SmartApollo {
     super.catchError(error)
     this.firstRunReject()
     this.loadingDone(error)
-    this.nextResult(this.observer.currentResult())
+    this.nextResult(this.observer.getCurrentResult())
     // The observable closes the sub if an error occurs
     this.resubscribeToQuery()
   }

--- a/tests/demo/src/components/ChannelList.vue
+++ b/tests/demo/src/components/ChannelList.vue
@@ -1,7 +1,7 @@
 <script>
 import UserCurrent from './UserCurrent.vue'
 import MockSendMessage from './MockSendMessage.vue'
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 export default {
   name: 'ChannelList',

--- a/tests/demo/src/components/ChannelList.vue
+++ b/tests/demo/src/components/ChannelList.vue
@@ -1,7 +1,7 @@
 <script>
 import UserCurrent from './UserCurrent.vue'
 import MockSendMessage from './MockSendMessage.vue'
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   name: 'ChannelList',

--- a/tests/demo/src/components/ManualAddSmartQuery.vue
+++ b/tests/demo/src/components/ManualAddSmartQuery.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 export default {
   data () {
     return {

--- a/tests/demo/src/components/ManualAddSmartQuery.vue
+++ b/tests/demo/src/components/ManualAddSmartQuery.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 export default {
   data () {
     return {

--- a/tests/demo/src/components/MockSendMessage.vue
+++ b/tests/demo/src/components/MockSendMessage.vue
@@ -1,5 +1,5 @@
 <script>
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 export default {
   created () {

--- a/tests/demo/src/components/MockSendMessage.vue
+++ b/tests/demo/src/components/MockSendMessage.vue
@@ -1,5 +1,5 @@
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 export default {
   created () {

--- a/tests/demo/src/components/PartialError.vue
+++ b/tests/demo/src/components/PartialError.vue
@@ -1,5 +1,5 @@
 <script>
-import { gql } from '@apollo/client'
+import { gql } from '@apollo/client/core'
 
 function query (errorPolicy) {
   return {

--- a/tests/demo/src/components/PartialError.vue
+++ b/tests/demo/src/components/PartialError.vue
@@ -1,5 +1,5 @@
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client'
 
 function query (errorPolicy) {
   return {

--- a/types/apollo-provider.d.ts
+++ b/types/apollo-provider.d.ts
@@ -1,7 +1,7 @@
 /* eslint no-unused-vars: 0 */
 
 import Vue, { AsyncComponent } from 'vue'
-import { ApolloClient } from 'apollo-client'
+import { ApolloClient } from '@apollo/client/core'
 import {
   VueApolloComponentOptions,
   WatchLoading,

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -9,7 +9,7 @@ import {
   NetworkStatus,
   ApolloQueryResult,
   ApolloError
-} from 'apollo-client'
+} from '@apollo/client'
 import { FetchResult } from 'apollo-link'
 import { ServerError, ServerParseError } from 'apollo-link-http-common'
 import { DocumentNode, GraphQLError } from 'graphql'

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -12,7 +12,7 @@ import {
   FetchResult,
   ServerError,
   ServerParseError,
-} from '@apollo/client'
+} from '@apollo/client/core'
 import { DocumentNode, GraphQLError } from 'graphql'
 import { DeepApplyThisType } from './utils'
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -8,10 +8,11 @@ import {
   ObservableQuery,
   NetworkStatus,
   ApolloQueryResult,
-  ApolloError
+  ApolloError,
+  FetchResult,
+  ServerError,
+  ServerParseError,
 } from '@apollo/client'
-import { FetchResult } from 'apollo-link'
-import { ServerError, ServerParseError } from 'apollo-link-http-common'
 import { DocumentNode, GraphQLError } from 'graphql'
 import { DeepApplyThisType } from './utils'
 

--- a/types/test/App.ts
+++ b/types/test/App.ts
@@ -1,7 +1,7 @@
 // this example src is https://github.com/Akryum/vue-apollo-example
 import gql from 'graphql-tag'
 import Vue from 'vue'
-import { OperationVariables, ApolloQueryResult, ApolloError } from 'apollo-client'
+import { OperationVariables, ApolloQueryResult, ApolloError } from '@apollo/client'
 import { VueApolloQueryDefinition, VueApolloSubscribeToMoreOptions } from '../options'
 import { DocumentNode } from 'graphql'
 
@@ -401,5 +401,5 @@ export default Vue.extend({
 
     // enable to specify client when execute request
     this.$apollo.query({ query: gql`query mockQuery { id }`, client: 'test' })
-  }, 
+  },
 })

--- a/types/test/App.ts
+++ b/types/test/App.ts
@@ -1,6 +1,6 @@
 // this example src is https://github.com/Akryum/vue-apollo-example
 import Vue from 'vue'
-import { OperationVariables, ApolloQueryResult, gql } from '@apollo/client'
+import { OperationVariables, ApolloQueryResult, gql } from '@apollo/client/core'
 import { VueApolloQueryDefinition } from '../options'
 import { DocumentNode } from 'graphql'
 

--- a/types/test/App.ts
+++ b/types/test/App.ts
@@ -1,8 +1,7 @@
 // this example src is https://github.com/Akryum/vue-apollo-example
-import gql from 'graphql-tag'
 import Vue from 'vue'
-import { OperationVariables, ApolloQueryResult, ApolloError } from '@apollo/client'
-import { VueApolloQueryDefinition, VueApolloSubscribeToMoreOptions } from '../options'
+import { OperationVariables, ApolloQueryResult, gql } from '@apollo/client'
+import { VueApolloQueryDefinition } from '../options'
 import { DocumentNode } from 'graphql'
 
 const pageSize = 10

--- a/types/test/App.vue
+++ b/types/test/App.vue
@@ -1,5 +1,5 @@
 <script>
-import gql from 'graphql-tag'
+import { gql } from '@apollo/client';
 
 export default {
   data () {

--- a/types/test/App.vue
+++ b/types/test/App.vue
@@ -1,5 +1,5 @@
 <script>
-import { gql } from '@apollo/client';
+import { gql } from '@apollo/client/core';
 
 export default {
   data () {

--- a/types/test/Decorator.ts
+++ b/types/test/Decorator.ts
@@ -1,6 +1,6 @@
 import { Component, Vue } from 'vue-property-decorator'
 import gql from 'graphql-tag'
-import { OperationVariables } from 'apollo-client'
+import { OperationVariables } from '@apollo/client'
 import { VueApolloComponentOptions } from '../options'
 
 @Component({

--- a/types/test/Decorator.ts
+++ b/types/test/Decorator.ts
@@ -1,5 +1,5 @@
 import { Component, Vue } from 'vue-property-decorator'
-import { OperationVariables, gql } from '@apollo/client'
+import { OperationVariables, gql } from '@apollo/client/core'
 import { VueApolloComponentOptions } from '../options'
 
 @Component({

--- a/types/test/Decorator.ts
+++ b/types/test/Decorator.ts
@@ -1,6 +1,5 @@
 import { Component, Vue } from 'vue-property-decorator'
-import gql from 'graphql-tag'
-import { OperationVariables } from '@apollo/client'
+import { OperationVariables, gql } from '@apollo/client'
 import { VueApolloComponentOptions } from '../options'
 
 @Component({

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,8 +1,7 @@
 import Vue from 'vue'
 
 import 'isomorphic-fetch'
-import { ApolloClient } from '@apollo/client'
-import { HttpLink } from 'apollo-link-http'
+import { ApolloClient, HttpLink } from '@apollo/client'
 
 import VueApollo from '../index'
 import App from './App'

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 
 import 'isomorphic-fetch'
-import { ApolloClient } from 'apollo-client'
+import { ApolloClient } from '@apollo/client'
 import { HttpLink } from 'apollo-link-http'
 
 import VueApollo from '../index'

--- a/types/test/index.ts
+++ b/types/test/index.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue'
 
 import 'isomorphic-fetch'
-import { ApolloClient, HttpLink } from '@apollo/client'
+import { ApolloClient, HttpLink } from '@apollo/client/core'
 
 import VueApollo from '../index'
 import App from './App'

--- a/types/test/tsconfig.json
+++ b/types/test/tsconfig.json
@@ -21,7 +21,8 @@
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitAny": true,
-    "allowJs": true
+    "allowJs": true,
+    "esModuleInterop": true
   },
   "include": [
     "*.ts",

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -10,7 +10,7 @@ import {
   OperationVariables,
   Observable,
   FetchResult,
-} from '@apollo/client'
+} from '@apollo/client/core'
 import { ApolloProvider, VueApolloComponent } from './apollo-provider'
 import {
   VueApolloQueryDefinition,

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -8,9 +8,9 @@ import {
   MutationOptions,
   SubscriptionOptions,
   OperationVariables,
-} from 'apollo-client'
+} from '@apollo/client'
 import { FetchResult } from 'apollo-link'
-import { Observable } from 'apollo-client/util/Observable'
+import { Observable } from '@apollo/client'
 import { ApolloProvider, VueApolloComponent } from './apollo-provider'
 import {
   VueApolloQueryDefinition,
@@ -34,7 +34,7 @@ interface SmartApollo<V> {
   stop(): void
 }
 
-type PickedObservableQuery = Pick<ObservableQuery, 
+type PickedObservableQuery = Pick<ObservableQuery,
   'fetchMore' |
   'subscribeToMore' |
   'refetch' |

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -8,9 +8,9 @@ import {
   MutationOptions,
   SubscriptionOptions,
   OperationVariables,
+  Observable,
+  FetchResult,
 } from '@apollo/client'
-import { FetchResult } from 'apollo-link'
-import { Observable } from '@apollo/client'
 import { ApolloProvider, VueApolloComponent } from './apollo-provider'
 import {
   VueApolloQueryDefinition,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,7 +1645,7 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/node@*", "@types/node@>=6":
+"@types/node@*":
   version "12.7.11"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
   integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
@@ -1889,14 +1889,6 @@
     text-table "^0.2.0"
     webpack-log "^1.1.2"
 
-"@wry/context@^0.4.0":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.4.4.tgz#e50f5fa1d6cfaabf2977d1fda5ae91717f8815f8"
-  integrity sha512-LrKVLove/zw6h2Md/KZyWxIkFM6AoyKp71OqpH9Hiip1csjPVoD3tPxlbQUNxEnHENks3UGgNpSBCAfq9KWuag==
-  dependencies:
-    "@types/node" ">=6"
-    tslib "^1.9.3"
-
 "@wry/context@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.0.tgz#5ff84d0d5726b62c07045af8465f890eb3823c8c"
@@ -1904,7 +1896,7 @@
   dependencies:
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
+"@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -2079,35 +2071,6 @@ anymatch@^2.0.0:
   dependencies:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
-
-apollo-cache-inmemory@^1.2.9:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/apollo-cache-inmemory/-/apollo-cache-inmemory-1.6.3.tgz#826861d20baca4abc45f7ca7a874105905b8525d"
-  integrity sha512-S4B/zQNSuYc0M/1Wq8dJDTIO9yRgU0ZwDGnmlqxGGmFombOZb9mLjylewSfQKmjNpciZ7iUIBbJ0mHlPJTzdXg==
-  dependencies:
-    apollo-cache "^1.3.2"
-    apollo-utilities "^1.3.2"
-    optimism "^0.10.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
-apollo-cache@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.2.tgz#df4dce56240d6c95c613510d7e409f7214e6d26a"
-  integrity sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==
-  dependencies:
-    apollo-utilities "^1.3.2"
-    tslib "^1.9.3"
-
-apollo-utilities@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
-  integrity sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==
-  dependencies:
-    "@wry/equality" "^0.1.2"
-    fast-json-stable-stringify "^2.0.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
 
 app-root-path@^2.0.1:
   version "2.2.1"
@@ -7331,13 +7294,6 @@ opn@^5.1.0:
   dependencies:
     is-wsl "^1.1.0"
 
-optimism@^0.10.0:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.10.3.tgz#163268fdc741dea2fb50f300bedda80356445fd7"
-  integrity sha512-9A5pqGoQk49H6Vhjb9kPgAeeECfUDF6aIICbMDL23kDLStBn1MWk3YvcZ4xWF9CsSf6XEgvRLkXy4xof/56vVw==
-  dependencies:
-    "@wry/context" "^0.4.0"
-
 optimism@^0.11.3:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.11.4.tgz#cc8a9378b5e4f2ce2a2b5e4b109327755e65dc76"
@@ -9595,7 +9551,7 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.4:
+ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,35 +2099,7 @@ apollo-cache@^1.3.2:
     apollo-utilities "^1.3.2"
     tslib "^1.9.3"
 
-apollo-link-http-common@^0.2.15:
-  version "0.2.15"
-  resolved "https://registry.yarnpkg.com/apollo-link-http-common/-/apollo-link-http-common-0.2.15.tgz#304e67705122bf69a9abaded4351b10bc5efd6d9"
-  integrity sha512-+Heey4S2IPsPyTf8Ag3PugUupASJMW894iVps6hXbvwtg1aHSNMXUYO5VG7iRHkPzqpuzT4HMBanCTXPjtGzxg==
-  dependencies:
-    apollo-link "^1.2.13"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-
-apollo-link-http@^1.2.0:
-  version "1.5.16"
-  resolved "https://registry.yarnpkg.com/apollo-link-http/-/apollo-link-http-1.5.16.tgz#44fe760bcc2803b8a7f57fc9269173afb00f3814"
-  integrity sha512-IA3xA/OcrOzINRZEECI6IdhRp/Twom5X5L9jMehfzEo2AXdeRwAMlH5LuvTZHgKD8V1MBnXdM6YXawXkTDSmJw==
-  dependencies:
-    apollo-link "^1.2.13"
-    apollo-link-http-common "^0.2.15"
-    tslib "^1.9.3"
-
-apollo-link@^1.0.3, apollo-link@^1.2.13:
-  version "1.2.13"
-  resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
-  integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
-  dependencies:
-    apollo-utilities "^1.3.0"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable-ts "^0.8.20"
-
-apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
+apollo-utilities@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
   integrity sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==
@@ -10590,15 +10562,7 @@ ylru@^1.2.0:
   resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.2.1.tgz#f576b63341547989c1de7ba288760923b27fe84f"
   integrity sha512-faQrqNMzcPCHGVC2aaOINk13K+aaBDUPjGWl0teOXywElLjyVAB6Oe2jj62jHYtwsU49jXhScYbvPENK+6zAvQ==
 
-zen-observable-ts@^0.8.20:
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-0.8.20.tgz#44091e335d3fcbc97f6497e63e7f57d5b516b163"
-  integrity sha512-2rkjiPALhOtRaDX6pWyNqK1fnP5KkJJybYebopNSn6wDG1lxBoFs2+nwwXKoA6glHIrtwrfBBy6da0stkKtTAA==
-  dependencies:
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
-
-zen-observable@^0.8.0, zen-observable@^0.8.14:
+zen-observable@^0.8.14:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.14.tgz#d33058359d335bc0db1f0af66158b32872af3bf7"
   integrity sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,21 @@
 # yarn lockfile v1
 
 
+"@apollo/client@^3.0.0-beta.7":
+  version "3.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.0.0-beta.7.tgz#86b7f5b26eb28b4e8bfba244532d2cfcd1f4df00"
+  integrity sha512-bmwQPKdF0vNxik/cIaYMQMP3Eox1V0cPyyXuIjrNXw1QMvSeucnfgrO/hEpMWZcRzb7cP4eAdy2JlYPUBmvGuw==
+  dependencies:
+    "@types/zen-observable" "^0.8.0"
+    "@wry/equality" "^0.1.9"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-tag "^2.10.1"
+    optimism "^0.11.3"
+    symbol-observable "^1.2.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+    zen-observable "^0.8.14"
+
 "@babel/code-frame@7.0.0-beta.47":
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.47.tgz#d18c2f4c4ba8d093a2bcfab5616593bfe2441a27"
@@ -1882,7 +1897,14 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/context@^0.5.0":
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.5.0.tgz#5ff84d0d5726b62c07045af8465f890eb3823c8c"
+  integrity sha512-yW5XFrWbRvv2/f86+g0YAfko7671SQg7Epn8lYjux4MZmIvtPvK2ts+vG1QAPu2w6GuBioEJknRa7K2LFj2kQw==
+  dependencies:
+    tslib "^1.9.3"
+
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -2069,27 +2091,13 @@ apollo-cache-inmemory@^1.2.9:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
 
-apollo-cache@1.3.2, apollo-cache@^1.3.2:
+apollo-cache@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-cache/-/apollo-cache-1.3.2.tgz#df4dce56240d6c95c613510d7e409f7214e6d26a"
   integrity sha512-+KA685AV5ETEJfjZuviRTEImGA11uNBp/MJGnaCvkgr+BYRrGLruVKBv6WvyFod27WEB2sp7SsG8cNBKANhGLg==
   dependencies:
     apollo-utilities "^1.3.2"
     tslib "^1.9.3"
-
-apollo-client@^2.4.1:
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.4.tgz#872c32927263a0d34655c5ef8a8949fbb20b6140"
-  integrity sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==
-  dependencies:
-    "@types/zen-observable" "^0.8.0"
-    apollo-cache "1.3.2"
-    apollo-link "^1.0.0"
-    apollo-utilities "1.3.2"
-    symbol-observable "^1.0.2"
-    ts-invariant "^0.4.0"
-    tslib "^1.9.3"
-    zen-observable "^0.8.0"
 
 apollo-link-http-common@^0.2.15:
   version "0.2.15"
@@ -2109,7 +2117,7 @@ apollo-link-http@^1.2.0:
     apollo-link-http-common "^0.2.15"
     tslib "^1.9.3"
 
-apollo-link@^1.0.0, apollo-link@^1.0.3, apollo-link@^1.2.13:
+apollo-link@^1.0.3, apollo-link@^1.2.13:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.13.tgz#dff00fbf19dfcd90fddbc14b6a3f9a771acac6c4"
   integrity sha512-+iBMcYeevMm1JpYgwDEIDt/y0BB7VWyvlm/7x+TIPNLHCTCMgcEgDuW5kH86iQZWo0I7mNwQiTOz+/3ShPFmBw==
@@ -2119,7 +2127,7 @@ apollo-link@^1.0.0, apollo-link@^1.0.3, apollo-link@^1.2.13:
     tslib "^1.9.3"
     zen-observable-ts "^0.8.20"
 
-apollo-utilities@1.3.2, apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
+apollo-utilities@^1.3.0, apollo-utilities@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.3.2.tgz#8cbdcf8b012f664cd6cb5767f6130f5aed9115c9"
   integrity sha512-JWNHj8XChz7S4OZghV6yc9FNnzEXj285QYp/nLNh943iObycI5GTDO3NGR9Dth12LRrSFMeDOConPfPln+WGfg==
@@ -4842,7 +4850,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-graphql-tag@^2.5.0:
+graphql-tag@^2.10.1, graphql-tag@^2.5.0:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==
@@ -7358,6 +7366,13 @@ optimism@^0.10.0:
   dependencies:
     "@wry/context" "^0.4.0"
 
+optimism@^0.11.3:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.11.4.tgz#cc8a9378b5e4f2ce2a2b5e4b109327755e65dc76"
+  integrity sha512-a9dQJt/dvrxhkEGK/l1U+T4zJ9OyIOWGnRrbjxy8+mWHVR3C3phmKlRuh2YKkSVjTf8G1kVFVEqL9+s4E77wsg==
+  dependencies:
+    "@wry/context" "^0.5.0"
+
 optimist@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
@@ -9339,7 +9354,7 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-symbol-observable@^1.0.2:
+symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
@@ -9608,14 +9623,14 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-invariant@^0.4.0:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
 
-tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
@@ -10583,7 +10598,7 @@ zen-observable-ts@^0.8.20:
     tslib "^1.9.3"
     zen-observable "^0.8.0"
 
-zen-observable@^0.8.0:
+zen-observable@^0.8.0, zen-observable@^0.8.14:
   version "0.8.14"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.14.tgz#d33058359d335bc0db1f0af66158b32872af3bf7"
   integrity sha512-kQz39uonEjEESwh+qCi83kcC3rZJGh4mrZW7xjkSQYXkq//JZHTtKo+6yuVloTgMtzsIWOJrjIrKvk/dqm0L5g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4822,7 +4822,7 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-graphql-tag@^2.10.1, graphql-tag@^2.5.0:
+graphql-tag@^2.10.1:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.10.1.tgz#10aa41f1cd8fae5373eaf11f1f67260a3cad5e02"
   integrity sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg==


### PR DESCRIPTION
This PR preps `vue-apollo` for use with Apollo Client 3, using the beta `@apollo/client` package. 

**Note:** This PR is definitely a work in progress, since Apollo Client 3 is still in beta, and the `@apollo/client/core` bundle being referenced isn't yet available (we're using `vue-apollo` to help test that bundle). Tests will fail here until `@apollo/client/core` is ready.