### PR TITLE
Add `context` prop to ApolloMutation

### DIFF
--- a/packages/docs/src/api/apollo-mutation.md
+++ b/packages/docs/src/api/apollo-mutation.md
@@ -32,7 +32,8 @@ Example:
 - `update`: See [updating cache after mutation](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-update)
 - `refetchQueries`: See [refetching queries after mutation](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
 - `clientId`: id of the Apollo Client used by the query (defined in ApolloProvider `clients` option)
-- `tag`: String HTML tag name (default: `div`); if `undefined`, the component will be renderless (the content won't be wrapped in a tag)
+- `tag`: String HTML tag name (default: `div`); if `undefined`, the component will be renderless (the content won't be wrapped in a tag).
+- `context`: See [apollo context](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.mutate)
 
 ## Scoped slot props
 

--- a/packages/docs/src/api/apollo-query.md
+++ b/packages/docs/src/api/apollo-query.md
@@ -38,7 +38,7 @@ To enable support of `gql` string tag in Vue templates, see the necessary setup 
 - `fetchPolicy`: See [apollo fetchPolicy](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-fetchPolicy)
 - `pollInterval`: See [apollo pollInterval](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-pollInterval)
 - `notifyOnNetworkStatusChange`: See [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-notifyOnNetworkStatusChange)
-- `context`: See [apollo context](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-context)
+- `context`: See [apollo context](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.mutate)
 - `update`: Function to transform the result `data`, useful for picking a specific part of the response. Example: `:update="data => data.user.messages"`
 - `skip`: Boolean disabling query fetching
 - `clientId`: id of the Apollo Client used by the query (defined in ApolloProvider `clients` option)

--- a/packages/docs/src/zh-cn/api/apollo-mutation.md
+++ b/packages/docs/src/zh-cn/api/apollo-mutation.md
@@ -33,6 +33,7 @@
 - `refetchQueries`：详见 [变更后重新获取查询](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
 - `clientId`：查询所使用的 Apollo 客户端 id（在 ApolloProvider 的 `clients` 选项中定义）
 - `tag`：字符串，HTML 标签名（默认值：`div`）；如果是 `undefined`，该组件将成为无渲染组件（内容不会被包装在标签中）
+- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.mutate)
 
 ## 作用域插槽 props
 

--- a/packages/docs/src/zh-cn/api/apollo-query.md
+++ b/packages/docs/src/zh-cn/api/apollo-query.md
@@ -38,7 +38,7 @@
 - `fetchPolicy`：详见 [apollo fetchPolicy](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-fetchPolicy)
 - `pollInterval`：详见 [apollo pollInterval](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-pollInterval)
 - `notifyOnNetworkStatusChange`：详见 [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-notifyOnNetworkStatusChange)
-- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-context)
+- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.mutate)
 - `update`：用于转换结果 `data` 的函数，用于在响应中选择特定部分。示例：`:update="data => data.user.messages"`
 - `skip`：布尔值，禁用查询获取
 - `clientId`：查询所使用的 Apollo 客户端 id（在 ApolloProvider 的 `clients` 选项中定义）

--- a/packages/vue-apollo/src/components/ApolloMutation.js
+++ b/packages/vue-apollo/src/components/ApolloMutation.js
@@ -37,6 +37,11 @@ export default {
       type: String,
       default: 'div',
     },
+
+    context: {
+      type: Object,
+      default: undefined,
+    },
   },
 
   data () {
@@ -69,6 +74,7 @@ export default {
         optimisticResponse: this.optimisticResponse,
         update: this.update,
         refetchQueries: this.refetchQueries,
+        context: this.context,
         ...options,
       }).then(result => {
         this.$emit('done', result)


### PR DESCRIPTION
Given that `context` is a prop defined on `ApolloQuery`, it seams to reason that `context` should also be a prop on `ApolloMutation` (see #867).

This PR adds `context` as a prop on ApolloMutation. Additionally, links to `context`-related docs were broken and unfortunately there doesn't appear to anything better we can link to besides the `mutate()` docs of `ApolloClient`.

Note that there seems to be a few more broken links throughout the docs - I'll follow up with a fix for these 👍 
