### PR TITLE
Fix all broken links throughout docs

### DIFF
--- a/packages/docs/src/api/apollo-mutation.md
+++ b/packages/docs/src/api/apollo-mutation.md
@@ -28,11 +28,12 @@ Example:
 
 - `mutation`: GraphQL query (transformed by `graphql-tag`) or a function that receives the `gql` tag as argument and should return the transformed query
 - `variables`: Object of GraphQL variables
-- `optimisticResponse`: See [optimistic UI](https://www.apollographql.com/docs/react/features/optimistic-ui.html)
-- `update`: See [updating cache after mutation](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-update)
-- `refetchQueries`: See [refetching queries after mutation](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
+- `optimisticResponse`: See [optimistic UI](https://www.apollographql.com/docs/react/performance/optimistic-ui/)
+- `update`: See [updating cache after mutation](https://www.apollographql.com/docs/react/data/mutations/#options)
+- `refetchQueries`: See [refetching queries after mutation](https://www.apollographql.com/docs/react/data/mutations/#options)
 - `clientId`: id of the Apollo Client used by the query (defined in ApolloProvider `clients` option)
 - `tag`: String HTML tag name (default: `div`); if `undefined`, the component will be renderless (the content won't be wrapped in a tag)
+- `context`: See [apollo context](https://www.apollographql.com/docs/react/data/mutations/#options)
 
 ## Scoped slot props
 

--- a/packages/docs/src/api/apollo-query.md
+++ b/packages/docs/src/api/apollo-query.md
@@ -35,10 +35,10 @@ To enable support of `gql` string tag in Vue templates, see the necessary setup 
 
 - `query`: GraphQL query (transformed by `graphql-tag`) or a function that receives the `gql` tag as argument and should return the transformed query
 - `variables`: Object of GraphQL variables
-- `fetchPolicy`: See [apollo fetchPolicy](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-fetchPolicy)
-- `pollInterval`: See [apollo pollInterval](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-pollInterval)
-- `notifyOnNetworkStatusChange`: See [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-notifyOnNetworkStatusChange)
-- `context`: See [apollo context](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-context)
+- `fetchPolicy`: See [apollo fetchPolicy](https://www.apollographql.com/docs/react/data/queries/#options)
+- `pollInterval`: See [apollo pollInterval](https://www.apollographql.com/docs/react/data/queries/#options)
+- `notifyOnNetworkStatusChange`: See [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/data/queries/#options)
+- `context`: See [apollo context](https://www.apollographql.com/docs/react/data/queries/#options)
 - `update`: Function to transform the result `data`, useful for picking a specific part of the response. Example: `:update="data => data.user.messages"`
 - `skip`: Boolean disabling query fetching
 - `clientId`: id of the Apollo Client used by the query (defined in ApolloProvider `clients` option)
@@ -56,7 +56,7 @@ To enable support of `gql` string tag in Vue templates, see the necessary setup 
   - `result.fullData`: Raw data returned by the query (not transformed by the `update` prop)
   - `result.loading`: Boolean indicating that a request is in flight (you may need to set `notifyOnNetworkStatusChange` prop for it to change)
   - `result.error`: Eventual error for the current result
-  - `result.networkStatus`: See [apollo networkStatus](https://www.apollographql.com/docs/react/basics/queries.html#graphql-query-data-networkStatus)
+  - `result.networkStatus`: See [apollo networkStatus](https://www.apollographql.com/docs/react/data/queries/#result)
 - `query`: Smart Query associated with the component. It's useful to do some operations like `query.refetch()` or `query.fetchMore()`.
 - `isLoading`: Smart Query loading state
 - `gqlError`: first GraphQL error if any

--- a/packages/docs/src/api/smart-query.md
+++ b/packages/docs/src/api/smart-query.md
@@ -229,7 +229,7 @@ this.$apollo.queries.users.setVariables({
 
 ### setOptions
 
-Update the Apollo [watchQuery](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.watchQuery) options and refetch:
+Update the Apollo [watchQuery](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.watchQuery) options and refetch:
 
 ```js
 this.$apollo.queries.users.setOptions({

--- a/packages/docs/src/guide/apollo/mutations.md
+++ b/packages/docs/src/guide/apollo/mutations.md
@@ -4,7 +4,7 @@ Mutations are queries that change your data state on your apollo server.
 
 Use `this.$apollo.mutate()` to send a GraphQL mutation.
 
-For more info, visit the [apollo doc](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.mutate). There is a mutation-focused [example app](https://github.com/Akryum/vue-apollo-todos) you can look at.
+For more info, visit the [apollo doc](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.mutate). There is a mutation-focused [example app](https://github.com/Akryum/vue-apollo-todos) you can look at.
 
 ::: warning
 You shouldn't send the `__typename` fields in the variables, so it is not recommended to send an Apollo result object directly.

--- a/packages/docs/src/guide/apollo/queries.md
+++ b/packages/docs/src/guide/apollo/queries.md
@@ -140,7 +140,7 @@ You can use the apollo `watchQuery` options in the object, like:
  - `pollInterval`
  - ...
 
-See the [apollo doc](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.watchQuery) for more details.
+See the [apollo doc](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.watchQuery) for more details.
 
 For example, you could add the `fetchPolicy` apollo option like this:
 

--- a/packages/docs/src/migration/README.md
+++ b/packages/docs/src/migration/README.md
@@ -193,4 +193,4 @@ import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 ```
 
-Learn more at the [official apollo documentation](https://www.apollographql.com/docs/react/2.0-migration.html).
+Learn more at the [official apollo documentation](https://www.apollographql.com/docs/react/v2.5/recipes/2.0-migration).

--- a/packages/docs/src/zh-cn/api/apollo-mutation.md
+++ b/packages/docs/src/zh-cn/api/apollo-mutation.md
@@ -28,11 +28,12 @@
 
 - `mutation`：GraphQL 查询（由 `graphql-tag` 转换）或一个接收 `gql` 标签作为参数并返回转换后的查询的函数
 - `variables`：GraphQL 变量对象
-- `optimisticResponse`：详见 [乐观 UI](https://www.apollographql.com/docs/react/features/optimistic-ui.html)
-- `update`：详见 [变更后更新缓存](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-update)
-- `refetchQueries`：详见 [变更后重新获取查询](https://www.apollographql.com/docs/react/api/react-apollo.html#graphql-mutation-options-refetchQueries)
+- `optimisticResponse`：详见 [乐观 UI](https://www.apollographql.com/docs/react/performance/optimistic-ui/)
+- `update`：详见 [变更后更新缓存](https://www.apollographql.com/docs/react/data/mutations/#options)
+- `refetchQueries`：详见 [变更后重新获取查询](https://www.apollographql.com/docs/react/data/mutations/#options)
 - `clientId`：查询所使用的 Apollo 客户端 id（在 ApolloProvider 的 `clients` 选项中定义）
 - `tag`：字符串，HTML 标签名（默认值：`div`）；如果是 `undefined`，该组件将成为无渲染组件（内容不会被包装在标签中）
+- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/data/mutations/#options)
 
 ## 作用域插槽 props
 

--- a/packages/docs/src/zh-cn/api/apollo-query.md
+++ b/packages/docs/src/zh-cn/api/apollo-query.md
@@ -35,10 +35,10 @@
 
 - `query`：GraphQL 查询（由 `graphql-tag` 转换）或一个接收 `gql` 标签作为参数并返回转换后的查询的函数
 - `variables`：GraphQL 变量对象
-- `fetchPolicy`：详见 [apollo fetchPolicy](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-fetchPolicy)
-- `pollInterval`：详见 [apollo pollInterval](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-pollInterval)
-- `notifyOnNetworkStatusChange`：详见 [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-notifyOnNetworkStatusChange)
-- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/basics/queries.html#graphql-config-options-context)
+- `fetchPolicy`：详见 [apollo fetchPolicy](https://www.apollographql.com/docs/react/data/queries/#options)
+- `pollInterval`：详见 [apollo pollInterval](https://www.apollographql.com/docs/react/data/queries/#options)
+- `notifyOnNetworkStatusChange`：详见 [apollo notifyOnNetworkStatusChange](https://www.apollographql.com/docs/react/data/queries/#options)
+- `context`：详见 [apollo context](https://www.apollographql.com/docs/react/data/queries/#options)
 - `update`：用于转换结果 `data` 的函数，用于在响应中选择特定部分。示例：`:update="data => data.user.messages"`
 - `skip`：布尔值，禁用查询获取
 - `clientId`：查询所使用的 Apollo 客户端 id（在 ApolloProvider 的 `clients` 选项中定义）
@@ -56,7 +56,7 @@
   - `result.fullData`：查询返回的原始数据（未使用 `update` 属性转换）
   - `result.loading`：布尔值，表明请求正在进行中（你可能需要设置 `notifyOnNetworkStatusChange` 属性来修改它）
   - `result.error`：当前结果的最终错误
-  - `result.networkStatus`：详见 [apollo networkStatus](https://www.apollographql.com/docs/react/basics/queries.html#graphql-query-data-networkStatus)
+  - `result.networkStatus`：详见 [apollo networkStatus](https://www.apollographql.com/docs/react/data/queries/#result)
 - `query`：与组件关联的智能查询，用于执行 `query.refetch()` 或 `query.fetchMore()` 之类的操作
 - `isLoading`：智能查询加载状态
 - `gqlError`：第一个 GraphQL 错误（如果有）

--- a/packages/docs/src/zh-cn/api/smart-query.md
+++ b/packages/docs/src/zh-cn/api/smart-query.md
@@ -224,7 +224,7 @@ this.$apollo.queries.users.setVariables({
 
 ### setOptions
 
-更新 Apollo [watchQuery](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.watchQuery) 选项并重新获取：
+更新 Apollo [watchQuery](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.watchQuery) 选项并重新获取：
 
 ```js
 this.$apollo.queries.users.setOptions({

--- a/packages/docs/src/zh-cn/guide/apollo/queries.md
+++ b/packages/docs/src/zh-cn/guide/apollo/queries.md
@@ -140,7 +140,7 @@ apollo: {
  - `pollInterval`
  - ...
 
-更多细节请查看 [apollo 文档](https://www.apollographql.com/docs/react/api/apollo-client.html#ApolloClient.watchQuery)。
+更多细节请查看 [apollo 文档](https://www.apollographql.com/docs/react/api/apollo-client/#ApolloClient.watchQuery)。
 
 例如，你可以像这样添加 `fetchPolicy` apollo 选项：
 

--- a/packages/docs/src/zh-cn/migration/README.md
+++ b/packages/docs/src/zh-cn/migration/README.md
@@ -193,4 +193,4 @@ import { WebSocketLink } from 'apollo-link-ws'
 import { getMainDefinition } from 'apollo-utilities'
 ```
 
-了解更多请查看 [apollo 官方文档](https://www.apollographql.com/docs/react/2.0-migration.html)。
+了解更多请查看 [apollo 官方文档](https://www.apollographql.com/docs/react/v2.5/recipes/2.0-migration)。


### PR DESCRIPTION
Somewhere along the line, the official Apollo docs have updated their docs such that most of the links in vue-apollo's docs break. Hence, all links have been updated so that they redirect somewhere.

Note that unfortunately direct targets for some items (notably props/options) don't exist, so where necessary, a "best alternative" was chosen.