### PR TITLE
v4: Fix useResult type inferring 'any'

### DIFF
--- a/packages/vue-apollo-composable/src/useResult.ts
+++ b/packages/vue-apollo-composable/src/useResult.ts
@@ -1,13 +1,15 @@
 import { Ref, computed } from '@vue/composition-api'
 
 export function useResult<
+  TReturnValue = any,
+  TDefaultValue = any,
   TResult = any
 > (
   result: Ref<TResult>,
-  defaultValue: any = null,
-  pick: (data: TResult) => any = null,
+  defaultValue: TDefaultValue = null,
+  pick: (data: TResult) => TReturnValue = null,
 ) {
-  return computed(() => {
+  return computed<TDefaultValue | TReturnValue>(() => {
     const value = result.value
     if (value) {
       if (pick) {


### PR DESCRIPTION
`useResult` is great for reactive objects, but the unwrapped type is currently inferred as `any`. This results in unnecessary and unsafe casting. The type information is available to be inferred, but the `useResult` function is not using it.

This PR fixes the issue by providing stricter type inference to `useResult` and `computed` for the `defaultValue` and `pick` return values, which results in correct typing.

**Issue**

```graphql
# Simplified for this example
interface ProjectQuery {
  project: Project
}
```

Usage:

```typescript
const { result, loading } = useQuery<ProjectQuery>(...)
const project = useResult(result, {}, data => data.project)
```

❌ Typed as `const project: Readonly<Ref<Readonly<any>>>`

**PR Fix**

Usage:

```typescript
const { result, loading } = useQuery<ProjectQuery>(...)
const project = useResult(result, {}, data => data.project)
```

✅ Typed as `const project: Readonly<Ref<Readonly<Project> | Readonly<{}>>>`

```typescript
const project = useResult(result, undefined, data => data.project as Project) // undefined default
```

✅ Typed as `const project: Readonly<Ref<Readonly<Project> | undefined>>`