### PR TITLE
v4: Fix build glob portability

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   ],
   "private": true,
   "scripts": {
-    "build": "lerna run build --concurrency 1 --scope {vue-apollo,@vue/apollo}*",
+    "build": "lerna run build --concurrency 1 --scope \"{vue-apollo,@vue/apollo}*\"",
     "test": "lerna run test --concurrency 1"
   },
   "devDependencies": {


### PR DESCRIPTION
The glob in the `package.json` `build` is incompatible with Darwin bash/zsh glob format, and probably others. This patch just wraps the glob in quotes so it is passed as a literal to `lerna`, instead of being incorrectly expanded.