### PR TITLE
Hydration errors during SSR

### DIFF
--- a/packages/vue-apollo/src/smart-query.js
+++ b/packages/vue-apollo/src/smart-query.js
@@ -144,7 +144,7 @@ export default class SmartQuery extends SmartApollo {
     const { data, loading, error, errors } = result
 
     if (error || errors) {
-      this.firstRunReject()
+      this.firstRunReject(error)
     }
 
     if (!loading) {
@@ -197,7 +197,7 @@ export default class SmartQuery extends SmartApollo {
 
   catchError (error) {
     super.catchError(error)
-    this.firstRunReject()
+    this.firstRunReject(error)
     this.loadingDone(error)
     this.nextResult(this.observer.currentResult())
     // The observable closes the sub if an error occurs


### PR DESCRIPTION
Currently if a network error with a smart query that is using prefetch occures, it will throw a hydration error. This is not the normal behaviour of `serverPrefetch`. Normally the renderer will handle the error.

With this PR the error is correctly piped through to `serverPrefetch` and will be handled correctly.

Related to https://github.com/vuejs/vue-apollo/issues/585
