### PR TITLE
v4: useMutation, mutate.result type

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -34,7 +34,7 @@ export function useMutation<
   // Apollo Client
   const { resolveClient } = useApolloClient()
 
-  async function mutate (variables: TVariables = null, overrideOptions: Omit<UseMutationOptions, 'variables'>) {
+  async function mutate (variables: TVariables = null, overrideOptions?: Omit<UseMutationOptions<TResult, TVariables>, 'variables'>) {
     let currentDocument: DocumentNode
     if (typeof document === 'function') {
       currentDocument = document()

--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -53,7 +53,7 @@ export function useMutation<
     loading.value = true
     called.value = true
     try {
-      const result = await client.mutate({
+      const result = await client.mutate<TResult>({
         mutation: currentDocument,
         ...currentOptions,
         ...overrideOptions,


### PR DESCRIPTION
passing `<TResult>` from `useMutation` to underlying client.
```typescript
const { mutate } = useMutation<Result, Variables>(CheckTodoGql)
const { data } = await mutate({ id }, {})
```
`data` is typeof Result