### PR TITLE
Update serialize-javascript to 2.1.1 to fix github alert for xss in regular expressions

### DIFF
--- a/packages/vue-apollo/package.json
+++ b/packages/vue-apollo/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "serialize-javascript": "^2.1.0",
+    "serialize-javascript": "^2.1.1",
     "throttle-debounce": "^2.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13252,6 +13252,11 @@ serialize-javascript@^2.1.0:
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.0.tgz#9310276819efd0eb128258bb341957f6eb2fc570"
   integrity sha512-a/mxFfU00QT88umAJQsNWOnUKckhNCqOl028N48e7wFmo2/EHpTo9Wso+iJJCMrQnmFvcjto5RJdAHEvVhcyUQ==
 
+serialize-javascript@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.1.tgz#952907a04a3e3a75af7f73d92d15e233862048b2"
+  integrity sha512-MPLPRpD4FNqWq9tTIjYG5LesFouDhdyH0EPY3gVK4DRD5+g4aDqdNSzLIwceulo3Yj+PL1bPh6laE5+H6LTcrQ==
+
 serve-favicon@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/serve-favicon/-/serve-favicon-2.5.0.tgz#935d240cdfe0f5805307fdfe967d88942a2cbcf0"


### PR DESCRIPTION
Hello,

We had a security alert in our project, and I think it requires an update in `vue-apollo` in order to get it fixed.

![image](https://user-images.githubusercontent.com/304786/70394905-66abbb00-1a5e-11ea-86a7-3d99d850dc46.png)

We are using `vue-apollo@3.0.0`, but I think the version on `dev` branch is also using `serialize-javascript@2.1.0` - fix was done in `serialize-javascript@2.1.1`.

```bash
kinow@kinow-VirtualBox:~/Development/python/workspace/cylc-ui$ npm list 2>/dev/null | grep vue-apollo@ -A3 
├─┬ vue-apollo@3.0.0
│ ├── chalk@2.4.2 deduped
│ ├── serialize-javascript@2.1.0
│ └── throttle-debounce@2.1.0
```

Cheers
Bruno