### PR TITLE
docs: added instructions about mocking loading state

### DIFF
--- a/packages/docs/src/guide/testing.md
+++ b/packages/docs/src/guide/testing.md
@@ -7,62 +7,59 @@ To create unit tests for vue-apollo queries and mutations you can choose either 
 For simple query testing you can just set the components data and check how component renders with a Jest snapshot feature. Say, if you have a query to display all Vue heroes, you can add a mocked array with a single hero:
 
 ```js
-test("displayed heroes correctly with query data", () => {
-  const wrapper = shallowMount(App, { localVue });
+test('displayed heroes correctly with query data', () => {
+  const wrapper = shallowMount(App, { localVue })
   wrapper.setData({
     allHeroes: [
       {
-        id: "some-id",
-        name: "Evan You",
-        image:
-          "https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg",
-        twitter: "youyuxi",
-        github: "yyx990803"
-      }
-    ]
-  });
-  expect(wrapper.element).toMatchSnapshot();
-});
+        id: 'some-id',
+        name: 'Evan You',
+        image: 'https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg',
+        twitter: 'youyuxi',
+        github: 'yyx990803',
+      },
+    ],
+  })
+  expect(wrapper.element).toMatchSnapshot()
+})
 ```
-
 For simple mutation test you need to check if `$apollo` method `mutate` is called in your component. In the next example mutation was called in the `addHero` method:
 
 ```js
-test("called Apollo mutation in addHero() method", () => {
-  const mutate = jest.fn();
+test('called Apollo mutation in addHero() method', () => {
+  const mutate = jest.fn()
   const wrapper = mount(App, {
     localVue,
     mocks: {
       $apollo: {
-        mutate
-      }
-    }
-  });
-  wrapper.vm.addHero();
-  expect(mutate).toBeCalled();
-});
+        mutate,
+      },
+    },
+  })
+  wrapper.vm.addHero()
+  expect(mutate).toBeCalled()
+})
 ```
 
-### Testing loading state with mocking \$apollo
-
+### Testing loading state with mocking $apollo
 If you want to test how your component renders when results from the GraphQL API are still loading, you can also mock a loading state in respective Apollo queries:
 
 ```js
-test("called Apollo mutation in addHero() method", () => {
+test('renders correctly when loading allHeroes', () => {
   const wrapper = mount(App, {
     mocks: {
       $apollo: {
         queries: {
           allHeroes: {
-            loading: true
-          }
-        }
-      }
-    }
-  });
+            loading: true,
+          },
+        },
+      },
+    },
+  })
 
   expect(wrapper.element).toMatchSnapshot();
-});
+})
 ```
 
 ## Tests with mocked GraqhQL schema
@@ -97,9 +94,8 @@ const sourceSchema = `
     addHero(hero: HeroInput!): VueHero!
     deleteHero(name: String!): Boolean
   } 
-`;
+`
 ```
-
 Next step is to create an executable schema with `graphql-tools` method:
 
 ```js
@@ -109,7 +105,6 @@ const schema = makeExecutableSchema({
   typeDefs: sourceSchema,
 })
 ```
-
 After this you need to add mock functions to schema:
 
 ```js
@@ -119,7 +114,6 @@ addMockFunctionsToSchema({
   schema,
 })
 ```
-
 Specify the GraphQL query string:
 
 ```js
@@ -133,18 +127,16 @@ const query = `
       image
     }
   }
-`;
+`
 ```
-
 Call GraphQL query in the test case, save response to component data and then check if rendered component matches a snapshot:
 
 ```js
 graphql(schema, query).then(result => {
-  wrapper.setData(result.data);
-  expect(wrapper.element).toMatchSnapshot();
-});
+  wrapper.setData(result.data)
+  expect(wrapper.element).toMatchSnapshot()
+})
 ```
-
 In this case all string fields will be equal to `Hello World` and all number values will be negative. If you want to have more real-life response, you should specify resolvers for certain queries:
 
 ```js
@@ -152,32 +144,30 @@ const resolvers = {
   Query: {
     allHeroes: () => [
       {
-        id: "-pBE1JAyz",
-        name: "Evan You",
+        id: '-pBE1JAyz',
+        name: 'Evan You',
         image:
-          "https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg",
-        twitter: "youyuxi",
-        github: "yyx990803"
-      }
-    ]
-  }
-};
+          'https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg',
+        twitter: 'youyuxi',
+        github: 'yyx990803',
+      },
+    ],
+  },
+}
 ```
-
 Then you need to add resolvers to executable schema and set `preserveResolvers` property to true when adding mock functions:
 
 ```js
 const schema = makeExecutableSchema({
   typeDefs: sourceSchema,
-  resolvers
-});
+  resolvers,
+})
 
 addMockFunctionsToSchema({
   schema,
-  preserveResolvers: true
-});
+  preserveResolvers: true,
+})
 ```
-
 You can test mutations in the same way.
 
 ---

--- a/packages/docs/src/guide/testing.md
+++ b/packages/docs/src/guide/testing.md
@@ -7,38 +7,62 @@ To create unit tests for vue-apollo queries and mutations you can choose either 
 For simple query testing you can just set the components data and check how component renders with a Jest snapshot feature. Say, if you have a query to display all Vue heroes, you can add a mocked array with a single hero:
 
 ```js
-test('displayed heroes correctly with query data', () => {
-  const wrapper = shallowMount(App, { localVue })
+test("displayed heroes correctly with query data", () => {
+  const wrapper = shallowMount(App, { localVue });
   wrapper.setData({
     allHeroes: [
       {
-        id: 'some-id',
-        name: 'Evan You',
-        image: 'https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg',
-        twitter: 'youyuxi',
-        github: 'yyx990803',
-      },
-    ],
-  })
-  expect(wrapper.element).toMatchSnapshot()
-})
+        id: "some-id",
+        name: "Evan You",
+        image:
+          "https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg",
+        twitter: "youyuxi",
+        github: "yyx990803"
+      }
+    ]
+  });
+  expect(wrapper.element).toMatchSnapshot();
+});
 ```
+
 For simple mutation test you need to check if `$apollo` method `mutate` is called in your component. In the next example mutation was called in the `addHero` method:
 
 ```js
-test('called Apollo mutation in addHero() method', () => {
-  const mutate = jest.fn()
+test("called Apollo mutation in addHero() method", () => {
+  const mutate = jest.fn();
   const wrapper = mount(App, {
     localVue,
     mocks: {
       $apollo: {
-        mutate,
-      },
-    },
-  })
-  wrapper.vm.addHero()
-  expect(mutate).toBeCalled()
-})
+        mutate
+      }
+    }
+  });
+  wrapper.vm.addHero();
+  expect(mutate).toBeCalled();
+});
+```
+
+### Testing loading state with mocking \$apollo
+
+If you want to test how your component renders when results from the GraphQL API are still loading, you can also mock a loading state in respective Apollo queries:
+
+```js
+test("called Apollo mutation in addHero() method", () => {
+  const wrapper = mount(App, {
+    mocks: {
+      $apollo: {
+        queries: {
+          allHeroes: {
+            loading: true
+          }
+        }
+      }
+    }
+  });
+
+  expect(wrapper.element).toMatchSnapshot();
+});
 ```
 
 ## Tests with mocked GraqhQL schema
@@ -73,8 +97,9 @@ const sourceSchema = `
     addHero(hero: HeroInput!): VueHero!
     deleteHero(name: String!): Boolean
   } 
-`
+`;
 ```
+
 Next step is to create an executable schema with `graphql-tools` method:
 
 ```js
@@ -84,6 +109,7 @@ const schema = makeExecutableSchema({
   typeDefs: sourceSchema,
 })
 ```
+
 After this you need to add mock functions to schema:
 
 ```js
@@ -93,6 +119,7 @@ addMockFunctionsToSchema({
   schema,
 })
 ```
+
 Specify the GraphQL query string:
 
 ```js
@@ -106,16 +133,18 @@ const query = `
       image
     }
   }
-`
+`;
 ```
+
 Call GraphQL query in the test case, save response to component data and then check if rendered component matches a snapshot:
 
 ```js
 graphql(schema, query).then(result => {
-  wrapper.setData(result.data)
-  expect(wrapper.element).toMatchSnapshot()
-})
+  wrapper.setData(result.data);
+  expect(wrapper.element).toMatchSnapshot();
+});
 ```
+
 In this case all string fields will be equal to `Hello World` and all number values will be negative. If you want to have more real-life response, you should specify resolvers for certain queries:
 
 ```js
@@ -123,30 +152,32 @@ const resolvers = {
   Query: {
     allHeroes: () => [
       {
-        id: '-pBE1JAyz',
-        name: 'Evan You',
+        id: "-pBE1JAyz",
+        name: "Evan You",
         image:
-          'https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg',
-        twitter: 'youyuxi',
-        github: 'yyx990803',
-      },
-    ],
-  },
-}
+          "https://pbs.twimg.com/profile_images/888432310504370176/mhoGA4uj_400x400.jpg",
+        twitter: "youyuxi",
+        github: "yyx990803"
+      }
+    ]
+  }
+};
 ```
+
 Then you need to add resolvers to executable schema and set `preserveResolvers` property to true when adding mock functions:
 
 ```js
 const schema = makeExecutableSchema({
   typeDefs: sourceSchema,
-  resolvers,
-})
+  resolvers
+});
 
 addMockFunctionsToSchema({
   schema,
-  preserveResolvers: true,
-})
+  preserveResolvers: true
+});
 ```
+
 You can test mutations in the same way.
 
 ---


### PR DESCRIPTION
It's a small addition to testing doc showing how we can mock loading state when testing components with Apollo queries