### PR TITLE
v4: Fixes useMutation not taking a Ref

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -1,6 +1,6 @@
 import { DocumentNode } from 'graphql'
 import { MutationOptions, OperationVariables } from 'apollo-client'
-import { ref, onBeforeUnmount } from '@vue/composition-api'
+import { ref, onBeforeUnmount, isRef, Ref } from '@vue/composition-api'
 import { FetchResult } from 'apollo-link'
 import { useApolloClient } from './useApolloClient'
 import { ReactiveFunction } from './util/ReactiveFunction'
@@ -18,8 +18,8 @@ export function useMutation<
   TResult = any,
   TVariables = OperationVariables
 > (
-  document: DocumentNode | ReactiveFunction<DocumentNode>,
-  options: UseMutationOptions<TResult, TVariables> | ReactiveFunction<UseMutationOptions<TResult, TVariables>> = null,
+  document: DocumentNode | Ref<DocumentNode> | ReactiveFunction<DocumentNode>,
+  options: UseMutationOptions<TResult, TVariables> | Ref<UseMutationOptions<TResult, TVariables>> | ReactiveFunction<UseMutationOptions<TResult, TVariables>> = null,
 ) {
   if (!options) options = {}
 
@@ -38,6 +38,8 @@ export function useMutation<
     let currentDocument: DocumentNode
     if (typeof document === 'function') {
       currentDocument = document()
+    } else if (isRef(document)) {
+      currentDocument = document.value
     } else {
       currentDocument = document
     }
@@ -45,6 +47,8 @@ export function useMutation<
     let currentOptions: UseMutationOptions<TResult, TVariables>
     if (typeof options === 'function') {
       currentOptions = options()
+    } else if (isRef(options)) {
+      currentOptions = options.value
     } else {
       currentOptions = options
     }


### PR DESCRIPTION
Currently, `useMutation` is defined to not allow `document` or `options` to be a `Ref`. It works as expected, it just needs to be unwrapped in `mutate`. Here is example code that breaks in v4-alpha4, but works after this PR.

```typescript
const randomName = ref('')

const options = ref({ variables: { id: 1, name: randomName } })

// ❌ v4-alpha4 causes a type error on `options`
// ✅ works correctly after the PR
const { mutate } = useMutation(RandomNameMutation, options)

// button @click="randomizeName"
function randomizeName () {
  randomName.value = Math.random().toString()
  mutate()
}
```

In this case, clicking the `button` correctly runs the mutation with a new random name value every time.

---

*This PR resolves one of several issues found while creating a [graphql-code-generator](graphql-code-generator.com/) plugin for vue-apollo hooks, which can be tracked [here](https://github.com/dotansimha/graphql-code-generator/pull/3146).*