### PR TITLE
v4: Fix useMutation "mutate" optional arguments

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -34,7 +34,7 @@ export function useMutation<
   // Apollo Client
   const { resolveClient } = useApolloClient()
 
-  async function mutate (variables: TVariables = null, overrideOptions: Omit<UseMutationOptions, 'variables'>) {
+  async function mutate (variables: TVariables = null, overrideOptions: Omit<UseMutationOptions, 'variables'> = {}) {
     let currentDocument: DocumentNode
     if (typeof document === 'function') {
       currentDocument = document()


### PR DESCRIPTION
This fixes a type error in `useMutation`'s exported `mutate` function that required arguments to be specified, even though the intention was that [they are optional](https://v4.apollo.vuejs.org/guide-composable/mutation.html#variables). 

(This appears to have been caused by a typo - the first argument of `mutate` had a default value, but the second one didn't. I'm surprised that TypeScript didn't catch this.)

```typescript
const { mutate } = useMutation(...)

// ❌ v4-alpha4: Expected 2 arguments, but got 0
// ✅ works after this PR
mutate()
```

---

*This PR resolves one of several issues found while creating a [graphql-code-generator](graphql-code-generator.com/) plugin for vue-apollo hooks, which can be tracked [here](https://github.com/dotansimha/graphql-code-generator/pull/3146).*