### PR TITLE
pass TVariables to VueApolloQueryDefinition

### DIFF
--- a/packages/vue-apollo/types/vue-apollo.d.ts
+++ b/packages/vue-apollo/types/vue-apollo.d.ts
@@ -76,6 +76,6 @@ export interface DollarApollo<V> extends ApolloClientMethods {
 
   getClient<R = any>(): ApolloClient<R>
 
-  addSmartQuery<R = any>(key: string, options: VueApolloQueryDefinition<R>): SmartQuery<V>
+  addSmartQuery<R = any, TVariables = OperationVariables>(key: string, options: VueApolloQueryDefinition<R, TVariables>): SmartQuery<V>
   addSmartSubscription<R = any>(key: string, options: VueApolloSubscriptionDefinition): SmartSubscription<V>
 }


### PR DESCRIPTION
If I'm not wrong, the `TVariables` should be passed to the `VueApolloQueryDefinition` to allow query variables type check.