### PR TITLE
fix(ssr): reject serverPrefetch with error

### DIFF
--- a/packages/vue-apollo/src/smart-query.js
+++ b/packages/vue-apollo/src/smart-query.js
@@ -197,7 +197,7 @@ export default class SmartQuery extends SmartApollo {
 
   catchError (error) {
     super.catchError(error)
-    this.firstRunReject()
+    this.firstRunReject(error)
     this.loadingDone(error)
     this.nextResult(this.observer.currentResult())
     // The observable closes the sub if an error occurs


### PR DESCRIPTION
Currently on error the promises used in `serverPrefetch` are being rejected with no value. Vue doesn't consider this to be an error, which leads to a broken response where the component is not rendered, but SSR considered the render successful, so it's not possible to detect the error.

This should fix #897 and #900.

@Akryum, a quick merge would be appreciated, as currently it's a bit worrisome to use in production since a transient network error could lead to clients getting a broken response.