### PR TITLE
docs(smart-query): document `pollInterval` usage

### DIFF
--- a/packages/docs/src/api/smart-query.md
+++ b/packages/docs/src/api/smart-query.md
@@ -39,6 +39,12 @@ apollo: {
         message: this.pingInput,
       }
     },
+    // Polling interval in milliseconds
+    pollInterval: 10000,
+    // Or, set polling interval as a vue reactive property
+    pollInterval() {
+      return this.pollInterval;
+    },
     // Variables: deep object watch
     deep: false,
     // We use a custom update callback because


### PR DESCRIPTION
Show both static value usage and reactive prop usage.