### PR TITLE
fix(ssr): ignore pollInterval on server

### DIFF
--- a/packages/vue-apollo/src/smart-query.js
+++ b/packages/vue-apollo/src/smart-query.js
@@ -79,6 +79,17 @@ export default class SmartQuery extends SmartApollo {
     }
   }
 
+  generateApolloOptions (variables) {
+    const apolloOptions = super.generateApolloOptions(variables)
+
+    if (this.vm.$isServer) {
+      // Don't poll on the server, that would run indefinitely
+      delete apolloOptions.pollInterval
+    }
+
+    return apolloOptions
+  }
+
   executeApollo (variables) {
     const variablesJson = JSON.stringify(variables)
 


### PR DESCRIPTION
Currently a query with `pollInterval` set will start polling on the server during SSR, which leads to the polling happening indefinitely. This PR simply trims the `pollInterval` option to Apollo when running on the server.