### PR TITLE
Return TResult when calling mutate manually

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -36,7 +36,7 @@ export interface UseMutationOptionsWithVariables<
 }
 
 export interface UseMutationReturn<TResult, TVariables> {
-  mutate: (variables?: TVariables, overrideOptions?: Pick<UseMutationOptions<any, OperationVariables>, 'update' | 'optimisticResponse' | 'context' | 'updateQueries' | 'refetchQueries' | 'awaitRefetchQueries' | 'errorPolicy' | 'fetchPolicy' | 'clientId'>) => Promise<FetchResult<any, Record<string, any>, Record<string, any>>>
+  mutate: (variables?: TVariables, overrideOptions?: Pick<UseMutationOptions<any, OperationVariables>, 'update' | 'optimisticResponse' | 'context' | 'updateQueries' | 'refetchQueries' | 'awaitRefetchQueries' | 'errorPolicy' | 'fetchPolicy' | 'clientId'>) => Promise<FetchResult<TResult, Record<string, any>, Record<string, any>>>
   loading: Ref<boolean>
   error: Ref<Error>
   called: Ref<boolean>


### PR DESCRIPTION
If I'm not wrong, we should return TResult when calling mutate so the result is properly type checked.

Currently the result when calling `mutate` is any.