### PR TITLE
Fix for Issue #924 (Cannot Re-assign $apollo)

### DIFF
--- a/packages/vue-apollo/src/index.js
+++ b/packages/vue-apollo/src/index.js
@@ -38,14 +38,16 @@ export function install (Vue, options) {
   }
 
   // Lazy creation
-  Object.defineProperty(Vue.prototype, '$apollo', {
-    get () {
-      if (!this.$_apollo) {
-        this.$_apollo = new DollarApollo(this)
-      }
-      return this.$_apollo
-    },
-  })
+  if (!Vue.prototype.hasOwnProperty('$apollo')) {
+      Object.defineProperty(Vue.prototype, '$apollo', {
+        get () {
+          if (!this.$_apollo) {
+            this.$_apollo = new DollarApollo(this)
+          }
+          return this.$_apollo
+        },
+      })
+  }
 
   installMixin(Vue, vueVersion)
 

--- a/packages/vue-apollo/src/index.js
+++ b/packages/vue-apollo/src/index.js
@@ -39,14 +39,14 @@ export function install (Vue, options) {
 
   // Lazy creation
   if (!Vue.prototype.hasOwnProperty('$apollo')) {
-      Object.defineProperty(Vue.prototype, '$apollo', {
-        get () {
-          if (!this.$_apollo) {
-            this.$_apollo = new DollarApollo(this)
-          }
-          return this.$_apollo
-        },
-      })
+    Object.defineProperty(Vue.prototype, '$apollo', {
+      get () {
+        if (!this.$_apollo) {
+          this.$_apollo = new DollarApollo(this)
+        }
+        return this.$_apollo
+      },
+    })
   }
 
   installMixin(Vue, vueVersion)


### PR DESCRIPTION
https://github.com/vuejs/vue-apollo/issues/924

Added the recommended sanity check .hasOwnProperty that is best practice for .defineProperty to fix .$apollo redefinition bug when using more than one Vue application on a page, or multiple vue built standard web components, like a web component library.

This bug is a show stopper for using vue-apollo in standard web components but fortunately was easily fixable by adding the standard best practices check around the block to prevent redefinition.

Also worth noting that it appears this same issue it has occurred and crept back into this project several times.