### PR TITLE
Use MutateWithOptionalVariables for mutations without default values

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -67,7 +67,7 @@ export function useMutation<TResult = any, TVariables extends OperationVariables
 export function useMutation<TResult = any, TVariables extends OperationVariables = OperationVariables>(
   document: DocumentNode | ReactiveFunction<DocumentNode>,
   options?: UseMutationOptionsNoVariables<TResult, undefined> | ReactiveFunction<UseMutationOptionsNoVariables<TResult, undefined>>
-): UseMutationReturn<TResult, TVariables, MutateWithRequiredVariables<TResult, TVariables>>
+): UseMutationReturn<TResult, TVariables, MutateWithOptionalVariables<TResult, TVariables>>
 
 export function useMutation<
   TResult,


### PR DESCRIPTION
This PR fixes #948

Since no defaults are specified with the `useMutation` call, variables might be undefined. This means `MutateWithOptionalVariables` should be used in the return statement.