### PR TITLE
fix calling twice to next result when using cache

### DIFF
--- a/packages/vue-apollo/src/smart-query.js
+++ b/packages/vue-apollo/src/smart-query.js
@@ -104,7 +104,7 @@ export default class SmartQuery extends SmartApollo {
     if (this.options.fetchPolicy !== 'no-cache' || this.options.notifyOnNetworkStatusChange) {
       const currentResult = this.maySetLoading()
 
-      if (!currentResult.loading || this.options.notifyOnNetworkStatusChange) {
+      if ((!currentResult.loading || this.options.notifyOnNetworkStatusChange) && this.options.fetchPolicy !== 'cache-only' && this.options.fetchPolicy !== 'cache-first') {
         this.nextResult(currentResult)
       }
     }


### PR DESCRIPTION
Following #492, when setting `fetchPolicy` to `cache-only` or `cache-first` the `nextResult` is called twice upon startup.
First in `executeApollo` and second when the subscription is immediately updated.
This PR prevents from `executeApollo` to call `nextResult` in case of the above.