### PR TITLE
(V4) Update @vue/composition-api to v0.6.1

### DIFF
--- a/packages/test-e2e-composition/package.json
+++ b/packages/test-e2e-composition/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@vue/apollo-composable": "^4.0.0-alpha.8",
     "@vue/apollo-util": "^4.0.0-alpha.6",
-    "@vue/composition-api": "^0.3.2",
+    "@vue/composition-api": "^0.6.1",
     "core-js": "^3.1.2",
     "graphql-type-json": "^0.3.0",
     "marked": "^0.7.0",

--- a/packages/test-ssr-composition/package.json
+++ b/packages/test-ssr-composition/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@vue/apollo-composable": "^4.0.0-alpha.8",
-    "@vue/composition-api": "^0.3.3",
+    "@vue/composition-api": "^0.6.1",
     "core-js": "^3.1.2",
     "graphql-type-json": "^0.2.1",
     "isomorphic-fetch": "^2.2.1",

--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -37,7 +37,7 @@
     "throttle-debounce": "^2.1.0"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^0.3.4",
+    "@vue/composition-api": "^0.6.1",
     "apollo-client": "^2.0.0",
     "apollo-link": "^1.0.0",
     "graphql": "^14.5.8",
@@ -46,7 +46,7 @@
   },
   "devDependencies": {
     "@types/throttle-debounce": "^2.1.0",
-    "@vue/composition-api": "^0.3.4",
+    "@vue/composition-api": "^0.6.1",
     "typescript": "^3.7.2"
   }
 }

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -319,6 +319,8 @@ export function useQuery<
   watch(documentRef, value => {
     currentDocument = value
     restart()
+  }, {
+    immediate: true
   })
 
   // Applying variables
@@ -333,6 +335,7 @@ export function useQuery<
     currentVariablesSerialized = serialized
   }, {
     deep: true,
+    immediate: true
   })
 
   // Applying options
@@ -348,6 +351,7 @@ export function useQuery<
     restart()
   }, {
     deep: true,
+    immediate: true
   })
 
   // Fefetch
@@ -400,6 +404,8 @@ export function useQuery<
         item.unsubscribeFns.forEach(fn => fn())
         item.unsubscribeFns = []
       })
+    }, {
+      immediate: true
     })
   }
 
@@ -430,6 +436,8 @@ export function useQuery<
     } else {
       stop()
     }
+  }, {
+    immediate: true
   })
 
   // Teardown

--- a/packages/vue-apollo-composable/src/useSubscription.ts
+++ b/packages/vue-apollo-composable/src/useSubscription.ts
@@ -200,6 +200,7 @@ export function useSubscription <
     restart()
   }, {
     deep: true,
+    immediate: true
   })
 
   // Applying document
@@ -207,6 +208,8 @@ export function useSubscription <
   watch(documentRef, value => {
     currentDocument = value
     restart()
+  }, {
+    immediate: true
   })
 
   // Applying variables
@@ -221,6 +224,7 @@ export function useSubscription <
     currentVariablesSerialized = serialized
   }, {
     deep: true,
+    immediate: true
   })
 
   // Internal enabled returned to user
@@ -243,6 +247,8 @@ export function useSubscription <
     } else {
       stop()
     }
+  }, {
+    immediate: true
   })
 
   // Teardown

--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -67,6 +67,8 @@ function track (loading: Ref<boolean>, type: keyof LoadingTracking) {
       tracking[type].value += mod
       appTracking[type].value += mod
     }
+  }, {
+    immediate: true
   })
 
   onBeforeUnmount(() => {

--- a/packages/vue-apollo-composable/src/util/paramToReactive.ts
+++ b/packages/vue-apollo-composable/src/util/paramToReactive.ts
@@ -1,7 +1,7 @@
 import { Ref, isRef, reactive, computed } from '@vue/composition-api'
 import { ReactiveFunction } from './ReactiveFunction'
 
-export function paramToReactive<T> (param: T | Ref<T> | ReactiveFunction<T>): T | Ref<T> {
+export function paramToReactive<T extends object> (param: T | Ref<T> | ReactiveFunction<T>): T | Ref<T> {
   if (isRef(param)) {
     return param
   } else if (typeof param === 'function') {

--- a/packages/vue-apollo-composable/src/util/paramToRef.ts
+++ b/packages/vue-apollo-composable/src/util/paramToRef.ts
@@ -1,4 +1,4 @@
-import { Ref, isRef, computed, ref, UnwrapRef } from '@vue/composition-api'
+import { Ref, isRef, computed, ref } from '@vue/composition-api'
 import { ReactiveFunction } from './ReactiveFunction'
 
 export function paramToRef<T> (param: T | Ref<T> | ReactiveFunction<T>): Ref<T> {

--- a/packages/vue-apollo-composable/src/util/paramToRef.ts
+++ b/packages/vue-apollo-composable/src/util/paramToRef.ts
@@ -1,4 +1,4 @@
-import { Ref, isRef, computed, ref } from '@vue/composition-api'
+import { Ref, isRef, computed, ref, UnwrapRef } from '@vue/composition-api'
 import { ReactiveFunction } from './ReactiveFunction'
 
 export function paramToRef<T> (param: T | Ref<T> | ReactiveFunction<T>): Ref<T> {
@@ -7,6 +7,6 @@ export function paramToRef<T> (param: T | Ref<T> | ReactiveFunction<T>): Ref<T> 
   } else if (typeof param === 'function') {
     return computed(param as ReactiveFunction<T>)
   } else {
-    return ref(param)
+    return ref(param) as Ref<T>
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2672,12 +2672,12 @@
     source-map "~0.6.1"
     vue-template-es2015-compiler "^1.9.0"
 
-"@vue/composition-api@^0.3.2", "@vue/composition-api@^0.3.3", "@vue/composition-api@^0.3.4":
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.3.4.tgz#43d2c3377173cfe1d02e51e3342bcf0fbde9c4b6"
-  integrity sha512-aMbg/pEk0PSQAIFyWWLqbAmaCCTx1kFq+49KZslIBJH9Wqos7eEPLtMv4gGxd/EcciBIgfbtUXaXGg/O3mheRA==
+"@vue/composition-api@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@vue/composition-api/-/composition-api-0.6.1.tgz#0a32e7d18e4b69912e3547e11d0c85e770de6825"
+  integrity sha512-NfP6kiBDXkYWrzFwK9IBem5MQSXMujIl8QDBJuLx0Y/6pwK3PC+F7dFDhja+H03SE6WwLleZASM6+zY3BT3Bkw==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^2.0.0"
 
 "@vue/eslint-config-standard@^4.0.0":
   version "4.0.0"
@@ -14617,6 +14617,11 @@ tslib@^1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
+
+tslib@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.0.tgz#18d13fc2dce04051e20f074cc8387fd8089ce4f3"
+  integrity sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
this fixes #1001

With the change of @vue/composition-api v0.6.0, the behavior of the watch API changed. 

https://github.com/vuejs/composition-api/ releases/tag/v0.6.0

> The lazy option of watch has been replaced by the The opposite immediate option, which defaults to false. (It's ignored when using the effect signature). 

This will prevent useQuery from executing the query immediately.

This PR includes the following changes

- Update @vue/composition-api (to v0.6.1)
- Add immediate option to the use of the watch API
- Fix type errors
