### PR TITLE
docs: enclose vue-apollo in backticks

### DIFF
--- a/packages/docs/src/guide/README.md
+++ b/packages/docs/src/guide/README.md
@@ -10,7 +10,7 @@ This library integrates [apollo](https://www.apollographql.com/) in your [Vue](h
 
 ## Become a sponsor
 
-Is your company using vue-apollo or vue-cli-plugin-apollo to build awesome apps? Join the other sponsors and add your logo on this documentation! Supporting me on GitHub allows me to work less for a job and to work more on Free Open Source Software such as vue-apollo! Thank you!
+Is your company using `vue-apollo` or `vue-cli-plugin-apollo` to build awesome apps? Join the other sponsors and add your logo on this documentation! Supporting me on GitHub allows me to work less for a job and to work more on Free Open Source Software such as `vue-apollo`! Thank you!
 
 <sponsor-button/>
 

--- a/packages/docs/src/guide/apollo/queries.md
+++ b/packages/docs/src/guide/apollo/queries.md
@@ -89,7 +89,7 @@ apollo: {
 }
 ```
 
-Notice how `world` is different from `hello`; vue-apollo won't guess which data you want to put in the component from the query result. By default, it will just try the name you are using for the data in the component (which is the key in the `apollo` object), in this case `world`. If the names don't match, you can use `update` option to tell vue-apollo what to use as data from the result:
+Notice how `world` is different from `hello`; `vue-apollo` won't guess which data you want to put in the component from the query result. By default, it will just try the name you are using for the data in the component (which is the key in the `apollo` object), in this case `world`. If the names don't match, you can use `update` option to tell `vue-apollo` what to use as data from the result:
 
 ```js
 apollo: {
@@ -112,7 +112,7 @@ apollo: {
 }
 ```
 
-In this example, we rename the `hello` field to `world` so that vue-apollo can automatically infer what should be retrieved from the result.
+In this example, we rename the `hello` field to `world` so that `vue-apollo` can automatically infer what should be retrieved from the result.
 
 ## Query with parameters
 
@@ -445,4 +445,4 @@ Internally, this method is called for each query entry in the component `apollo`
 
 ## Advanced options
 
-There are even more options specific to vue-apollo, see the [API Reference](../../api/smart-query.md).
+There are even more options specific to `vue-apollo`, see the [API Reference](../../api/smart-query.md).

--- a/packages/docs/src/guide/ssr.md
+++ b/packages/docs/src/guide/ssr.md
@@ -6,7 +6,7 @@
 
 ## Vue CLI plugin
 
-I made a plugin for [vue-cli](http://cli.vuejs.org) so you can transform your vue-apollo app into an isomorphic SSR app in literally two minutes! ✨🚀
+I made a plugin for [vue-cli](http://cli.vuejs.org) so you can transform your `vue-apollo` app into an isomorphic SSR app in literally two minutes! ✨🚀
 
 In your vue-cli 3 project:
 

--- a/packages/docs/src/guide/testing.md
+++ b/packages/docs/src/guide/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-To create unit tests for vue-apollo queries and mutations you can choose either a simple testing or tests with mocked GraqhQL schema. All examples here use [Jest](https://jestjs.io/) and [vue-test-utils](https://github.com/vuejs/vue-test-utils)
+To create unit tests for `vue-apollo` queries and mutations you can choose either a simple testing or tests with mocked GraqhQL schema. All examples here use [Jest](https://jestjs.io/) and [vue-test-utils](https://github.com/vuejs/vue-test-utils)
 
 ## Simple tests
 

--- a/packages/docs/src/zh-cn/guide/README.md
+++ b/packages/docs/src/zh-cn/guide/README.md
@@ -14,7 +14,7 @@
 
 ## Become a sponsor
 
-你的公司是否使用了 vue-apollo 或 vue-cli-plugin-apollo 来构建出色的应用程序？加入资助者并成为赞助商，在此文档中添加你的 logo！在 Patreon 上支持我，将节省我用于谋生的工作时间，从而能够在如 vue-apollo 一样的免费开源软件上工作更多！谢谢！
+你的公司是否使用了 `vue-apollo` 或 vue-cli-plugin-apollo 来构建出色的应用程序？加入资助者并成为赞助商，在此文档中添加你的 logo！在 Patreon 上支持我，将节省我用于谋生的工作时间，从而能够在如 vue-apollo 一样的免费开源软件上工作更多！谢谢！
 
 <p style="text-align: center;">
   <a href="https://www.patreon.com/akryum" target="_blank">

--- a/packages/docs/src/zh-cn/guide/apollo/queries.md
+++ b/packages/docs/src/zh-cn/guide/apollo/queries.md
@@ -89,7 +89,7 @@ apollo: {
 }
 ```
 
-注意 `world` 与 `hello` 的不同之处：vue-apollo 不会去猜测你想要将哪些数据从查询结果中放入组件中。默认情况下，它只会尝试你在组件中使用的数据名称（即 `apollo` 对象中的键），在本例中为 `world`。如果名称不匹配，你可以使用 `update` 选项来告诉 vue-apollo 在结果中使用什么样的数据：
+注意 `world` 与 `hello` 的不同之处：`vue-apollo` 不会去猜测你想要将哪些数据从查询结果中放入组件中。默认情况下，它只会尝试你在组件中使用的数据名称（即 `apollo` 对象中的键），在本例中为 `world`。如果名称不匹配，你可以使用 `update` 选项来告诉 vue-apollo 在结果中使用什么样的数据：
 
 ```js
 apollo: {
@@ -445,4 +445,4 @@ created () {
 
 ## 高级选项
 
-还有更多专用于 vue-apollo 的选项，请查看 [API 参考](../../api/smart-query.md)。
+还有更多专用于 `vue-apollo` 的选项，请查看 [API 参考](../../api/smart-query.md)。

--- a/packages/docs/src/zh-cn/guide/testing.md
+++ b/packages/docs/src/zh-cn/guide/testing.md
@@ -1,6 +1,6 @@
 # 测试
 
-要为 vue-apollo 查询和变更创建单元测试，你可以选择简单测试或使用模拟 GraqhQL schema 进行测试。所有的示例都使用了 [Jest](https://jestjs.io/) 和 [vue-test-utils](https://github.com/vuejs/vue-test-utils)。
+要为 `vue-apollo` 查询和变更创建单元测试，你可以选择简单测试或使用模拟 GraqhQL schema 进行测试。所有的示例都使用了 [Jest](https://jestjs.io/) 和 [vue-test-utils](https://github.com/vuejs/vue-test-utils)。
 
 ## 简单测试
 


### PR DESCRIPTION
These changes enclose every mention of `vue-apollo` in backticks, to make it consistent across all the docs.