### PR TITLE
v4: mark useEventHook param as not optional

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -26,10 +26,10 @@ export interface UseMutationReturn<TResult, TVariables> {
   loading: Ref<boolean>
   error: Ref<Error>
   called: Ref<boolean>
-  onDone: (fn: (param?: FetchResult<TResult, Record<string, any>, Record<string, any>>) => void) => {
+  onDone: (fn: (param: FetchResult<TResult, Record<string, any>, Record<string, any>>) => void) => {
       off: () => void
   };
-  onError: (fn: (param?: Error) => void) => {
+  onError: (fn: (param: Error) => void) => {
       off: () => void
   };
 };

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -50,10 +50,10 @@ export interface UseQueryReturn<TResult, TVariables> {
   refetch: (variables?: TVariables) => Promise<ApolloQueryResult<TResult>>
   fetchMore: <K extends keyof TVariables>(options: FetchMoreQueryOptions<TVariables, K> & FetchMoreOptions<TResult, TVariables>) => Promise<ApolloQueryResult<TResult>>
   subscribeToMore: <TSubscriptionVariables = OperationVariables, TSubscriptionData = TResult>(options: SubscribeToMoreOptions<TResult, TSubscriptionVariables, TSubscriptionData> | Ref<SubscribeToMoreOptions<TResult, TSubscriptionVariables, TSubscriptionData>> | ReactiveFunction<SubscribeToMoreOptions<TResult, TSubscriptionVariables, TSubscriptionData>>) => void
-  onResult: (fn: (param?: ApolloQueryResult<TResult>) => void) => {
+  onResult: (fn: (param: ApolloQueryResult<TResult>) => void) => {
       off: () => void
   }
-  onError: (fn: (param?: Error) => void) => {
+  onError: (fn: (param: Error) => void) => {
       off: () => void
   }
 }

--- a/packages/vue-apollo-composable/src/useSubscription.ts
+++ b/packages/vue-apollo-composable/src/useSubscription.ts
@@ -33,10 +33,10 @@ export interface UseSubscriptionReturn<TResult, TVariables> {
   variables: Ref<TVariables>
   options: UseSubscriptionOptions<TResult, TVariables> | Ref<UseSubscriptionOptions<TResult, TVariables>>
   subscription: Ref<Observable<FetchResult<TResult, Record<string, any>, Record<string, any>>>>
-  onResult: (fn: (param?: FetchResult<TResult, Record<string, any>, Record<string, any>>) => void) => {
+  onResult: (fn: (param: FetchResult<TResult, Record<string, any>, Record<string, any>>) => void) => {
       off: () => void
   }
-  onError: (fn: (param?: Error) => void) => {
+  onError: (fn: (param: Error) => void) => {
       off: () => void
   }
 }

--- a/packages/vue-apollo-composable/src/util/useEventHook.ts
+++ b/packages/vue-apollo-composable/src/util/useEventHook.ts
@@ -1,21 +1,21 @@
 export function useEventHook<TParam = any> () {
-  const fns: ((param?: TParam) => void)[] = []
+  const fns: ((param: TParam) => void)[] = []
 
-  function on (fn: (param?: TParam) => void) {
+  function on (fn: (param: TParam) => void) {
     fns.push(fn)
     return {
       off: () => off(fn),
     }
   }
 
-  function off (fn: (param?: TParam) => void) {
+  function off (fn: (param: TParam) => void) {
     const index = fns.indexOf(fn)
     if (index !== -1) {
       fns.splice(index, 1)
     }
   }
 
-  function trigger (param?: TParam) {
+  function trigger (param: TParam) {
     for (const fn of fns) {
       fn(param)
     }


### PR DESCRIPTION
`useEventHook` param is currently marked optional.
This disables the possibility to destructure the query/mutation results directly in the callback parameter.
For example:
```typescript
const { onResult } = useQuery(document);
onResult(({ data: { queryField } }) => {
    // use queryField
});
```
would currently yield a typescript error:
```
Property 'data' does not exist on type 'ApolloQueryResult<any> | undefined'
```
(note the `| undefined` also the event is declared as `const resultEvent = useEventHook<ApolloQueryResult<any>>()`)

This PR solves the issue.

It is safe because:
 - it only affects the type system, not the actual JS code
 - nowhere in the source tree `trigger` is called with an undefined value (at least not in a way allowed by the type system)
 - a possibly undefined result can still be expressed if necessary, but it has to be explicit: `useEventHook<Param | undefined>()`