### PR TITLE
build es module

### DIFF
--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -21,14 +21,24 @@
   "publishConfig": {
     "access": "public"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "type": "module",
+  "main": "dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "require": "./dist/commonjs/index.js",
+      "default": "./dist/esm/index.js"
+    }
+  },
+  "types": "dist/esm/index.d.ts",
+  "module": "./dist/esm/index.js",
   "files": [
     "dist"
   ],
   "scripts": {
     "dev": "yarn build --watch",
-    "build": "tsc --outDir dist -d",
+    "build": "npm run build:esm && npm run build:commonjs",
+    "build:esm": "tsc -m es2015 -d --lib \"DOM\",\"ES5\",\"es2020.symbol.wellknown\" --outDir dist/esm",
+    "build:commonjs": "tsc -m commonjs --lib \"DOM\",\"ES5\",\"es2020.symbol.wellknown\" --outDir dist/commonjs",
     "prepublishOnly": "yarn test && yarn build",
     "test": "yarn test:types",
     "test:types": "tsc -p tests/types/"

--- a/packages/vue-apollo-composable/tsconfig.json
+++ b/packages/vue-apollo-composable/tsconfig.json
@@ -3,8 +3,9 @@
     "target": "es5",
     "module": "commonjs",
     "sourceMap": true,
+    "outDir": "dist",
+    "moduleResolution": "node"
   },
-  "include": [
-    "src/**/*",
-  ],
+  "exclude": ["node_modules", "**/node_modules/*"],
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
#### What?
Added an ES module build along with the existing `commonjs` build to `@vue/apollo-composable`

#### Why?
I expect many Vue 3 projects will rely on `vite` instead of webpack as a bundler. Vite famously works with ES modules and is required to get proper named imports (see for example #1029). commonjs imports *kind of* work with default imports but a proper ES module build will be required in the long run.