### PR TITLE
Fix getAppTracking for Vue 3 support

### DIFF
--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -11,7 +11,7 @@ export interface AppLoadingTracking extends LoadingTracking {
 }
 
 export function getAppTracking () {
-  const vm = getCurrentInstance()
+  const vm: any = getCurrentInstance()
   const root: any = vm.$root || vm.root
   let appTracking: AppLoadingTracking
 

--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -11,7 +11,8 @@ export interface AppLoadingTracking extends LoadingTracking {
 }
 
 export function getAppTracking () {
-  const root: any = getCurrentInstance().$root
+  const vm = getCurrentInstance()
+  const root: any = vm.$root || vm.root
   let appTracking: AppLoadingTracking
 
   if (!root._apolloAppTracking) {


### PR DESCRIPTION
@Akryum  In Vue 2's composition API, the instance has a [`vm.$root` property](https://github.com/vuejs/composition-api/blob/master/src/component/componentProxy.ts#L15) with the root component.

However, in Vue 3, the [property is called `vm.root`](https://github.com/vuejs/vue-next/blob/master/packages/runtime-core/src/component.ts#L179) (without dollar).

With this small change I was able to upgrade a project using latest `@vue/apollo-composable` alpha to Vue 3.