### PR TITLE
Fix useQuery to support Vue 3

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -137,10 +137,12 @@ export function useQuery<
   // SSR
   let firstResolve: Function
   let firstReject: Function
-  onServerPrefetch(() => new Promise((resolve, reject) => {
-    firstResolve = resolve
-    firstReject = reject
-  }).then(stop).catch(stop))
+  if (onServerPrefetch) {
+    onServerPrefetch(() => new Promise((resolve, reject) => {
+      firstResolve = resolve
+      firstReject = reject
+    }).then(stop).catch(stop))
+  }
 
   // Apollo Client
   const { resolveClient } = useApolloClient()

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -1,5 +1,4 @@
-import { ref, Ref, isRef, computed, watch, onServerPrefetch, getCurrentInstance, onBeforeUnmount } from 'vue-demi'
-import Vue from 'vue'
+import { ref, Ref, isRef, computed, watch, onServerPrefetch, getCurrentInstance, onBeforeUnmount, nextTick } from 'vue-demi'
 import { DocumentNode } from 'graphql'
 import {
   OperationVariables,
@@ -290,7 +289,7 @@ export function useQuery<
   function baseRestart () {
     if (!started || restarting) return
     restarting = true
-    Vue.nextTick(() => {
+    nextTick(() => {
       if (started) {
         stop()
         start()


### PR DESCRIPTION
`onServerPrefetch` only exists in Vue 2's composition API, not in Vue 3 as far as I know.