### PR TITLE
Rename Components -> Component API in header

### DIFF
--- a/packages/docs/src/.vuepress/config.js
+++ b/packages/docs/src/.vuepress/config.js
@@ -53,7 +53,7 @@ module.exports = {
                 link: '/guide-composable/',
               },
               {
-                text: 'Components',
+                text: 'Component API',
                 link: '/guide-components/',
               },
               {


### PR DESCRIPTION
To make it clear that it's 1 among 3 ways of using vue-apollo. 

Before, I thought there were 2 ways:

![image](https://user-images.githubusercontent.com/251288/90322263-5bc7f500-df20-11ea-9915-898b0aa23716.png)

After:

![image](https://user-images.githubusercontent.com/251288/90322269-684c4d80-df20-11ea-9940-012e18eaa3cb.png)
