### PR TITLE
fix: unresolved promises in ssr (#940)

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -135,12 +135,24 @@ export function useQuery<
   const networkStatus = ref<number>()
 
   // SSR
-  let firstResolve: Function
-  let firstReject: Function
-  onServerPrefetch(() => new Promise((resolve, reject) => {
-    firstResolve = resolve
-    firstReject = reject
-  }).then(stop).catch(stop))
+  let firstResolve: Function | undefined
+  let firstReject: Function | undefined
+  onServerPrefetch(async () => {
+    if (!isEnabled.value || (isServer && currentOptions.value.prefetch === false)) return;
+
+    return new Promise((resolve, reject) => {
+      firstResolve = () => {
+        resolve();
+        firstResolve = undefined;
+        firstReject = undefined;
+      }
+      firstReject = () => {
+        reject();
+        firstResolve = undefined;
+        firstReject = undefined;
+      }
+    }).then(stop).catch(stop)
+  })
 
   // Apollo Client
   const { resolveClient } = useApolloClient()
@@ -155,8 +167,13 @@ export function useQuery<
    * Starts watching the query
    */
   function start () {
-    if (started || !isEnabled.value) return
-    if (isServer && currentOptions.value.prefetch === false) return
+    if (
+      started || !isEnabled.value ||
+      (isServer && currentOptions.value.prefetch === false)
+    ) {
+      if (firstResolve) firstResolve();
+      return
+    }
 
     started = true
     loading.value = true
@@ -215,7 +232,6 @@ export function useQuery<
     } else {
       if (firstResolve) {
         firstResolve()
-        firstResolve = null
         stop()
       }
     }
@@ -233,7 +249,6 @@ export function useQuery<
     processError(queryError)
     if (firstReject) {
       firstReject(queryError)
-      firstReject = null
       stop()
     }
     // The observable closes the sub if an error occurs
@@ -262,6 +277,7 @@ export function useQuery<
    * Stop watching the query
    */
   function stop () {
+    if (firstResolve) firstResolve();
     if (!started) return
     started = false
     loading.value = false


### PR DESCRIPTION
Fixes #940

After evaluating a few alternatives, this one performed reliably on all my components.

- If onServerPrefetch the query is not enabled or prefetch is disabled, resolve firstResult
- If start is cancelled and a firstResult is pending, resolve firstResult
- If stop is called and firstResult is pending, resolve firstResult

The remaining cases are coverd with the old conditions.
- If query returns an error and firstResult is pending, reject with firstReject
- If query completes successfully and firstResult is pending, resolve firstResult