### PR TITLE
Fixed calling result hook twice when fetching data from cache

### DIFF
--- a/packages/vue-apollo/src/smart-query.js
+++ b/packages/vue-apollo/src/smart-query.js
@@ -115,7 +115,7 @@ export default class SmartQuery extends SmartApollo {
     if (this.options.fetchPolicy !== 'no-cache' || this.options.notifyOnNetworkStatusChange) {
       const currentResult = this.maySetLoading()
 
-      if (!currentResult.loading || this.options.notifyOnNetworkStatusChange) {
+      if (this.options.notifyOnNetworkStatusChange) {
         this.nextResult(currentResult)
       }
     }


### PR DESCRIPTION
Close #492 

Currently, when the component is fetching data from the cache, the `nextResult` method is called explicitly by `executeApollo` when `loading` is not `false`. This doesn't involve Apollo Observable subscription and leads to calling query `result` hook twice: once by `executeApollo` and once by `observer.next`

This PR attempts to fix this behaviour