### PR TITLE
fix(composable): Clear previous error when recieving a result

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -250,7 +250,7 @@ export function useQueryImpl<
   function onNextResult (queryResult: ApolloQueryResult<TResult>) {
     // Remove any previous error that may still be present from the last fetch (so result handlers
     // don't receive old errors that may not even be applicable anymore).
-    error.value = null;
+    error.value = null
 
     processNextResult(queryResult)
 

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -248,6 +248,10 @@ export function useQueryImpl<
   }
 
   function onNextResult (queryResult: ApolloQueryResult<TResult>) {
+    // Remove any previous error that may still be present from the last fetch (so result handlers
+    // don't receive old errors that may not even be applicable anymore).
+    error.value = null;
+
     processNextResult(queryResult)
 
     // Result errors


### PR DESCRIPTION
When receiving new results (either because `pollInterval`is set or because `.refetch()` was called), any errors that were previously caught are kept in cache. This means that subsequent updates will always continue to see the last error, even if the latest response from the server was OK. This PR adresses that by explicitly clearing any existing errors before handling new results.

This should address #1119.